### PR TITLE
Include pt-br (Brazilian Portuguese) labels

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
   "languages": [
+    "pt-br",
     "pt",
     "en"
   ],

--- a/executive/Q10351100/current/popolo-m17n.json
+++ b/executive/Q10351100/current/popolo-m17n.json
@@ -18,6 +18,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "João Doria Júnior",
         "lang:pt": "João Doria Júnior",
         "lang:en": "João Doria Júnior"
       },
@@ -69,6 +70,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Olavo Setúbal",
         "lang:pt": "Olavo Setúbal",
         "lang:en": "Olavo Setúbal"
       },
@@ -85,6 +87,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Celso Pitta",
         "lang:pt": "Celso Pitta",
         "lang:en": "Celso Pitta"
       },
@@ -101,6 +104,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Ademar Pereira de Barros",
         "lang:pt": "Ademar Pereira de Barros",
         "lang:en": "Adhemar de Barros"
       },
@@ -117,6 +121,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Gilberto Kassab",
         "lang:pt": "Gilberto Kassab",
         "lang:en": "Gilberto Kassab"
       },
@@ -133,6 +138,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "José Serra",
         "lang:pt": "José Serra",
         "lang:en": "José Serra"
       },
@@ -149,6 +155,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Marta Suplicy",
         "lang:pt": "Marta Suplicy",
         "lang:en": "Marta Suplicy"
       },
@@ -184,6 +191,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Paulo Maluf",
         "lang:pt": "Paulo Maluf",
         "lang:en": "Paulo Maluf"
       },
@@ -237,6 +245,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "prefeitura municipal de São Paulo",
         "lang:pt": "Prefeitura do Município de São Paulo",
         "lang:en": "municipal prefecture of São Paulo"
       },
@@ -252,6 +261,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Democratas",
         "lang:pt": "Democratas",
         "lang:en": "Democrats"
       },
@@ -266,6 +276,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido da Social Democracia Brasileira",
         "lang:pt": "Partido da Social Democracia Brasileira",
         "lang:en": "Brazilian Social Democracy Party"
       },
@@ -294,6 +305,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Aliança Renovadora Nacionalista",
         "lang:pt": "Aliança Renovadora Nacional",
         "lang:en": "National Renewal Alliance Party"
       },
@@ -308,6 +320,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido dos Trabalhadores",
         "lang:pt": "Partido dos Trabalhadores",
         "lang:en": "Workers' Party"
       },
@@ -322,6 +335,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido Progressista",
         "lang:pt": "Partido Progressista",
         "lang:en": "Progressive Party"
       },
@@ -366,6 +380,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -392,6 +407,7 @@
         "Q53934877"
       ],
       "type": {
+        "lang:pt-br": "capital",
         "lang:pt": "capital",
         "lang:en": "capital"
       },
@@ -417,6 +433,7 @@
         "Q53864923"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q10351100/current/query-results.json
+++ b/executive/Q10351100/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ {
@@ -36,6 +36,11 @@
         "type" : "literal",
         "value" : "São Paulo"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q24255165"
@@ -88,6 +93,11 @@
         "type" : "literal",
         "value" : "Prefeitura do Município de São Paulo"
       },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de São Paulo"
+      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q10310619-4e0ac4d9-4d48-190c-f216-0896918b6134"
@@ -95,6 +105,11 @@
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q174"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Aliança Renovadora Nacionalista"
       }
     }, {
       "item" : {
@@ -115,6 +130,11 @@
         "type" : "literal",
         "value" : "São Paulo"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q24255165"
@@ -167,6 +187,11 @@
         "type" : "literal",
         "value" : "Prefeitura do Município de São Paulo"
       },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de São Paulo"
+      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q10311413-bc77641c-4efe-8ba1-36cc-e596d3829b00"
@@ -183,6 +208,11 @@
       "facebook" : {
         "type" : "literal",
         "value" : "jdoriajr"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "João Doria Júnior"
       }
     }, {
       "item" : {
@@ -200,6 +230,11 @@
       },
       "district_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "São Paulo"
       },
@@ -255,6 +290,11 @@
         "type" : "literal",
         "value" : "Prefeitura do Município de São Paulo"
       },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de São Paulo"
+      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q10353688-40434ce3-46da-1527-9205-804f04496e71"
@@ -296,6 +336,11 @@
         "type" : "literal",
         "value" : "São Paulo"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q24255165"
@@ -348,6 +393,11 @@
         "type" : "literal",
         "value" : "Prefeitura do Município de São Paulo"
       },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de São Paulo"
+      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q1669473-56b0ba3f-4f4a-570f-a540-c7a98affe667"
@@ -355,6 +405,11 @@
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q174"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Partido da Social Democracia Brasileira"
       }
     }, {
       "party" : {
@@ -389,6 +444,11 @@
         "type" : "literal",
         "value" : "São Paulo"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q24255165"
@@ -441,6 +501,11 @@
         "type" : "literal",
         "value" : "Prefeitura do Município de São Paulo"
       },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de São Paulo"
+      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q1797226-ed143384-4d62-ad26-61b3-776d8d3c29c6"
@@ -448,6 +513,16 @@
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q174"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Democratas"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Olavo Setúbal"
       }
     }, {
       "party" : {
@@ -482,6 +557,11 @@
         "type" : "literal",
         "value" : "São Paulo"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q24255165"
@@ -534,6 +614,11 @@
         "type" : "literal",
         "value" : "Prefeitura do Município de São Paulo"
       },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de São Paulo"
+      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q1857846-CC5BB7B8-B3FC-41EB-8601-BD3155AC966B"
@@ -541,6 +626,16 @@
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q174"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Partido Progressista"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Celso Pitta"
       }
     }, {
       "party" : {
@@ -572,6 +667,11 @@
       },
       "district_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "São Paulo"
       },
@@ -627,6 +727,11 @@
         "type" : "literal",
         "value" : "Prefeitura do Município de São Paulo"
       },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de São Paulo"
+      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q199624-1a4ee03c-4e73-bb6b-374c-9c689ec81a1a"
@@ -634,6 +739,11 @@
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q174"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Ademar Pereira de Barros"
       }
     }, {
       "party" : {
@@ -668,6 +778,11 @@
         "type" : "literal",
         "value" : "São Paulo"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q24255165"
@@ -720,6 +835,11 @@
         "type" : "literal",
         "value" : "Prefeitura do Município de São Paulo"
       },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de São Paulo"
+      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q2546210-89ac76a0-4dc2-1bf3-295e-48c7064e37d5"
@@ -727,6 +847,11 @@
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q174"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Gilberto Kassab"
       }
     }, {
       "party" : {
@@ -761,6 +886,11 @@
         "type" : "literal",
         "value" : "São Paulo"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q24255165"
@@ -813,6 +943,11 @@
         "type" : "literal",
         "value" : "Prefeitura do Município de São Paulo"
       },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de São Paulo"
+      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q379563-FF17F8FE-E53B-4D49-9605-CBCB504259D0"
@@ -820,6 +955,16 @@
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q174"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Partido da Social Democracia Brasileira"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "José Serra"
       }
     }, {
       "party" : {
@@ -854,6 +999,11 @@
         "type" : "literal",
         "value" : "São Paulo"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q24255165"
@@ -906,6 +1056,11 @@
         "type" : "literal",
         "value" : "Prefeitura do Município de São Paulo"
       },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de São Paulo"
+      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q463614-5ed0d655-48e1-1477-fc37-dc2a3b89be26"
@@ -914,9 +1069,19 @@
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q174"
       },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Partido dos Trabalhadores"
+      },
       "facebook" : {
         "type" : "literal",
         "value" : "MartaNossaPrefeita"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Marta Suplicy"
       }
     }, {
       "party" : {
@@ -948,6 +1113,11 @@
       },
       "district_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "São Paulo"
       },
@@ -1003,6 +1173,11 @@
         "type" : "literal",
         "value" : "Prefeitura do Município de São Paulo"
       },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de São Paulo"
+      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q4776958-59f99f30-48a4-5208-f510-7f67e5754329"
@@ -1010,6 +1185,11 @@
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q174"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Partido Progressista"
       }
     }, {
       "party" : {
@@ -1044,6 +1224,11 @@
         "type" : "literal",
         "value" : "São Paulo"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q24255165"
@@ -1096,6 +1281,11 @@
         "type" : "literal",
         "value" : "Prefeitura do Município de São Paulo"
       },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de São Paulo"
+      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q549835-40204e52-41f1-dcbb-aaad-92ebc258da14"
@@ -1103,6 +1293,16 @@
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q174"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Partido Progressista"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Paulo Maluf"
       }
     }, {
       "party" : {
@@ -1137,6 +1337,11 @@
         "type" : "literal",
         "value" : "São Paulo"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q24255165"
@@ -1189,6 +1394,11 @@
         "type" : "literal",
         "value" : "Prefeitura do Município de São Paulo"
       },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de São Paulo"
+      },
       "statement" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/statement/Q7386110-157a2661-4eaf-e4af-64af-7866b799c5a7"
@@ -1196,6 +1406,11 @@
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q174"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Partido da Social Democracia Brasileira"
       }
     }, {
       "item" : {
@@ -1216,6 +1431,11 @@
         "type" : "literal",
         "value" : "São Paulo"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q24255165"
@@ -1267,6 +1487,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Prefeitura do Município de São Paulo"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de São Paulo"
       },
       "statement" : {
         "type" : "uri",

--- a/executive/Q10351100/current/query-used.rq
+++ b/executive/Q10351100/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q24255165 }
   BIND(wd:Q10351100 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q30263897/current/popolo-m17n.json
+++ b/executive/Q30263897/current/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Alexandre Kalil",
         "lang:pt": "Alexandre Kalil",
         "lang:en": "Alexandre Kalil"
       },
@@ -23,6 +24,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "prefeitura municipal de Belo Horizonte",
         "lang:en": "municipal prefecture of Belo Horizonte"
       },
       "id": "Q30263897",
@@ -53,6 +55,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -79,6 +82,7 @@
         "Q53864924"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -104,6 +108,7 @@
         "Q53935007"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },
@@ -121,10 +126,12 @@
       "area_id": "Q42800",
       "role_superclass_code": "Q53926035",
       "role_superclass": {
+        "lang:pt-br": "Prefeito de Belo Horizonte",
         "lang:en": "Mayor of Belo Horizonte"
       },
       "role_code": "Q53926035",
       "role": {
+        "lang:pt-br": "Prefeito de Belo Horizonte",
         "lang:en": "Mayor of Belo Horizonte"
       }
     }

--- a/executive/Q30263897/current/query-results.json
+++ b/executive/Q30263897/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ {
@@ -18,6 +18,11 @@
         "type" : "literal",
         "value" : "Belo Horizonte"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Belo Horizonte"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53926035"
@@ -31,10 +36,20 @@
         "type" : "literal",
         "value" : "Mayor of Belo Horizonte"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Prefeito de Belo Horizonte"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Mayor of Belo Horizonte"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Prefeito de Belo Horizonte"
       },
       "item" : {
         "type" : "uri",
@@ -50,6 +65,11 @@
         "type" : "literal",
         "value" : "Alexandre Kalil"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Alexandre Kalil"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q30263897"
@@ -58,6 +78,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "municipal prefecture of Belo Horizonte"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de Belo Horizonte"
       },
       "statement" : {
         "type" : "uri",

--- a/executive/Q30263897/current/query-used.rq
+++ b/executive/Q30263897/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53926035 }
   BIND(wd:Q30263897 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q5015503/current/popolo-m17n.json
+++ b/executive/Q5015503/current/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Floriano Peixoto",
         "lang:pt": "Floriano Peixoto",
         "lang:en": "Floriano Peixoto"
       },
@@ -18,6 +19,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Tancredo Neves",
         "lang:pt": "Tancredo Neves",
         "lang:en": "Tancredo Neves"
       },
@@ -66,6 +68,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Artur da Costa e Silva",
         "lang:pt": "Costa e Silva",
         "lang:en": "Artur da Costa e Silva"
       },
@@ -130,6 +133,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Michel Temer",
         "lang:pt": "Michel Temer",
         "lang:en": "Michel Temer"
       },
@@ -151,6 +155,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "Ministério do Brasil",
         "lang:pt": "Ministério do Brasil",
         "lang:en": "cabinet of Brazil"
       },
@@ -166,6 +171,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Movimento Democrático Brasileiro",
         "lang:pt": "Movimento Democrático Brasileiro",
         "lang:en": "Democratic Movement Party"
       },
@@ -180,6 +186,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Aliança Renovadora Nacionalista",
         "lang:pt": "Aliança Renovadora Nacional",
         "lang:en": "National Renewal Alliance Party"
       },
@@ -238,6 +245,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -256,11 +264,13 @@
       "area_id": "Q155",
       "role_superclass_code": "Q5176750",
       "role_superclass": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       },
       "role_code": "Q5176750",
       "role": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       }
@@ -273,11 +283,13 @@
       "area_id": "Q155",
       "role_superclass_code": "Q5176750",
       "role_superclass": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       },
       "role_code": "Q5176750",
       "role": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       }
@@ -290,11 +302,13 @@
       "area_id": "Q155",
       "role_superclass_code": "Q5176750",
       "role_superclass": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       },
       "role_code": "Q5176750",
       "role": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       }
@@ -307,11 +321,13 @@
       "area_id": "Q155",
       "role_superclass_code": "Q5176750",
       "role_superclass": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       },
       "role_code": "Q5176750",
       "role": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       }
@@ -324,11 +340,13 @@
       "area_id": "Q155",
       "role_superclass_code": "Q5176750",
       "role_superclass": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       },
       "role_code": "Q5176750",
       "role": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       }
@@ -341,11 +359,13 @@
       "area_id": "Q155",
       "role_superclass_code": "Q5176750",
       "role_superclass": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       },
       "role_code": "Q5176750",
       "role": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       }
@@ -358,11 +378,13 @@
       "area_id": "Q155",
       "role_superclass_code": "Q5176750",
       "role_superclass": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       },
       "role_code": "Q5176750",
       "role": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       }
@@ -375,11 +397,13 @@
       "area_id": "Q155",
       "role_superclass_code": "Q5176750",
       "role_superclass": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       },
       "role_code": "Q5176750",
       "role": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       }
@@ -393,11 +417,13 @@
       "start_date": "2016-08-31",
       "role_superclass_code": "Q5176750",
       "role_superclass": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       },
       "role_code": "Q5176750",
       "role": {
+        "lang:pt-br": "Presidente do Brasil",
         "lang:pt": "Presidente do Brasil",
         "lang:en": "President of Brazil"
       }

--- a/executive/Q5015503/current/query-results.json
+++ b/executive/Q5015503/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "district_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Brasil"
+      },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Brasil"
       },
@@ -36,6 +41,11 @@
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -43,6 +53,11 @@
       },
       "role_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
@@ -60,6 +75,11 @@
         "type" : "literal",
         "value" : "Floriano Peixoto"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Floriano Peixoto"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5015503"
@@ -71,6 +91,11 @@
       },
       "org_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Ministério do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Ministério do Brasil"
       },
@@ -97,6 +122,11 @@
         "type" : "literal",
         "value" : "Brasil"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Brasil"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5176750"
@@ -115,6 +145,11 @@
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -122,6 +157,11 @@
       },
       "role_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
@@ -139,6 +179,11 @@
         "type" : "literal",
         "value" : "Tancredo Neves"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Tancredo Neves"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5015503"
@@ -150,6 +195,11 @@
       },
       "org_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Ministério do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Ministério do Brasil"
       },
@@ -174,6 +224,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Movimento Democrático Brasileiro"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Movimento Democrático Brasileiro"
       }
     }, {
       "district" : {
@@ -187,6 +242,11 @@
       },
       "district_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Brasil"
+      },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Brasil"
       },
@@ -208,6 +268,11 @@
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -215,6 +280,11 @@
       },
       "role_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
@@ -243,6 +313,11 @@
       },
       "org_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Ministério do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Ministério do Brasil"
       },
@@ -283,6 +358,11 @@
         "type" : "literal",
         "value" : "Brasil"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Brasil"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5176750"
@@ -301,6 +381,11 @@
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -308,6 +393,11 @@
       },
       "role_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
@@ -336,6 +426,11 @@
       },
       "org_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Ministério do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Ministério do Brasil"
       },
@@ -376,6 +471,11 @@
         "type" : "literal",
         "value" : "Brasil"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Brasil"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5176750"
@@ -394,6 +494,11 @@
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -401,6 +506,11 @@
       },
       "role_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
@@ -418,6 +528,11 @@
         "type" : "literal",
         "value" : "Costa e Silva"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Artur da Costa e Silva"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5015503"
@@ -429,6 +544,11 @@
       },
       "org_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Ministério do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Ministério do Brasil"
       },
@@ -453,6 +573,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Aliança Renovadora Nacional"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Aliança Renovadora Nacionalista"
       }
     }, {
       "district" : {
@@ -466,6 +591,11 @@
       },
       "district_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Brasil"
+      },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Brasil"
       },
@@ -487,6 +617,11 @@
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -494,6 +629,11 @@
       },
       "role_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
@@ -522,6 +662,11 @@
       },
       "org_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Ministério do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Ministério do Brasil"
       },
@@ -562,6 +707,11 @@
         "type" : "literal",
         "value" : "Brasil"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Brasil"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5176750"
@@ -580,6 +730,11 @@
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -587,6 +742,11 @@
       },
       "role_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
@@ -615,6 +775,11 @@
       },
       "org_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Ministério do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Ministério do Brasil"
       },
@@ -655,6 +820,11 @@
         "type" : "literal",
         "value" : "Brasil"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Brasil"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5176750"
@@ -673,6 +843,11 @@
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -680,6 +855,11 @@
       },
       "role_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
@@ -708,6 +888,11 @@
       },
       "org_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Ministério do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Ministério do Brasil"
       },
@@ -748,6 +933,11 @@
         "type" : "literal",
         "value" : "Brasil"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Brasil"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5176750"
@@ -766,6 +956,11 @@
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -773,6 +968,11 @@
       },
       "role_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Presidente do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Presidente do Brasil"
       },
@@ -790,6 +990,11 @@
         "type" : "literal",
         "value" : "Michel Temer"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Michel Temer"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q5015503"
@@ -801,6 +1006,11 @@
       },
       "org_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Ministério do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Ministério do Brasil"
       },
@@ -823,6 +1033,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Movimento Democrático Brasileiro"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Movimento Democrático Brasileiro"
       },

--- a/executive/Q5015503/current/query-used.rq
+++ b/executive/Q5015503/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q5176750 }
   BIND(wd:Q5015503 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738322/current/popolo-m17n.json
+++ b/executive/Q53738322/current/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Geraldo Alckmin",
         "lang:pt": "Geraldo Alckmin",
         "lang:en": "Geraldo Alckmin"
       },
@@ -23,6 +24,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "cabinete do governador do estado de São Paulo",
         "lang:en": "cabinet of the governor of the state of Sao Paulo"
       },
       "id": "Q53738322",
@@ -37,6 +39,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido da Social Democracia Brasileira",
         "lang:pt": "Partido da Social Democracia Brasileira",
         "lang:en": "Brazilian Social Democracy Party"
       },
@@ -67,6 +70,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -93,6 +97,7 @@
         "Q53864923"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -111,10 +116,12 @@
       "area_id": "Q175",
       "role_superclass_code": "Q53739335",
       "role_superclass": {
+        "lang:pt-br": "governador do estado de São Paulo",
         "lang:en": "governor of the state of Sao Paulo"
       },
       "role_code": "Q53739335",
       "role": {
+        "lang:pt-br": "governador do estado de São Paulo",
         "lang:en": "governor of the state of Sao Paulo"
       }
     }

--- a/executive/Q53738322/current/query-results.json
+++ b/executive/Q53738322/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido da Social Democracia Brasileira"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido da Social Democracia Brasileira"
       },
@@ -36,6 +41,11 @@
         "type" : "literal",
         "value" : "São Paulo"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "São Paulo"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53739335"
@@ -49,10 +59,20 @@
         "type" : "literal",
         "value" : "governor of the state of Sao Paulo"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "governador do estado de São Paulo"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "governor of the state of Sao Paulo"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "governador do estado de São Paulo"
       },
       "name_en" : {
         "xml:lang" : "en",
@@ -64,6 +84,11 @@
         "type" : "literal",
         "value" : "Geraldo Alckmin"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Geraldo Alckmin"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53738322"
@@ -72,6 +97,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "cabinet of the governor of the state of Sao Paulo"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "cabinete do governador do estado de São Paulo"
       },
       "statement" : {
         "type" : "uri",

--- a/executive/Q53738322/current/query-used.rq
+++ b/executive/Q53738322/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739335 }
   BIND(wd:Q53738322 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738323/current/popolo-m17n.json
+++ b/executive/Q53738323/current/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Fernando Pimentel",
         "lang:pt": "Fernando Pimentel",
         "lang:en": "Fernando Pimentel"
       },
@@ -23,6 +24,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "cabinete do governador do estado de Minas Gerais",
         "lang:en": "cabinet of the governor of the state of Minas Gerais"
       },
       "id": "Q53738323",
@@ -37,6 +39,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido dos Trabalhadores",
         "lang:pt": "Partido dos Trabalhadores",
         "lang:en": "Workers' Party"
       },
@@ -67,6 +70,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -93,6 +97,7 @@
         "Q53864924"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -111,10 +116,12 @@
       "area_id": "Q39109",
       "role_superclass_code": "Q53739337",
       "role_superclass": {
+        "lang:pt-br": "governador do estado de Minas Gerais",
         "lang:en": "governor of the state of Minas Gerais"
       },
       "role_code": "Q53739337",
       "role": {
+        "lang:pt-br": "governador do estado de Minas Gerais",
         "lang:en": "governor of the state of Minas Gerais"
       }
     }

--- a/executive/Q53738323/current/query-results.json
+++ b/executive/Q53738323/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido dos Trabalhadores"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido dos Trabalhadores"
       },
@@ -36,6 +41,11 @@
         "type" : "literal",
         "value" : "Minas Gerais"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Minas Gerais"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53739337"
@@ -49,10 +59,20 @@
         "type" : "literal",
         "value" : "governor of the state of Minas Gerais"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "governador do estado de Minas Gerais"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "governor of the state of Minas Gerais"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "governador do estado de Minas Gerais"
       },
       "name_en" : {
         "xml:lang" : "en",
@@ -64,6 +84,11 @@
         "type" : "literal",
         "value" : "Fernando Pimentel"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Fernando Pimentel"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53738323"
@@ -72,6 +97,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "cabinet of the governor of the state of Minas Gerais"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "cabinete do governador do estado de Minas Gerais"
       },
       "statement" : {
         "type" : "uri",

--- a/executive/Q53738323/current/query-used.rq
+++ b/executive/Q53738323/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739337 }
   BIND(wd:Q53738323 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738324/current/popolo-m17n.json
+++ b/executive/Q53738324/current/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Luiz Fernando Pezão",
         "lang:pt": "Luiz Fernando de Souza",
         "lang:en": "Luiz Fernando Pezão"
       },
@@ -23,6 +24,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "cabinete do governador do estado do Rio de Janeiro",
         "lang:en": "cabinet of the governor of the state of Rio de Janeiro"
       },
       "id": "Q53738324",
@@ -37,6 +39,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Movimento Democrático Brasileiro",
         "lang:pt": "Movimento Democrático Brasileiro",
         "lang:en": "Democratic Movement Party"
       },
@@ -67,6 +70,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -93,6 +97,7 @@
         "Q53864925"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -111,10 +116,12 @@
       "area_id": "Q41428",
       "role_superclass_code": "Q53739338",
       "role_superclass": {
+        "lang:pt-br": "governador do estado do Rio de Janeiro",
         "lang:en": "governor of the state of Rio de Janeiro"
       },
       "role_code": "Q53739338",
       "role": {
+        "lang:pt-br": "governador do estado do Rio de Janeiro",
         "lang:en": "governor of the state of Rio de Janeiro"
       }
     }

--- a/executive/Q53738324/current/query-results.json
+++ b/executive/Q53738324/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Movimento Democrático Brasileiro"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Movimento Democrático Brasileiro"
       },
@@ -36,6 +41,11 @@
         "type" : "literal",
         "value" : "Rio de Janeiro"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Rio de Janeiro"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53739338"
@@ -49,10 +59,20 @@
         "type" : "literal",
         "value" : "governor of the state of Rio de Janeiro"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "governador do estado do Rio de Janeiro"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "governor of the state of Rio de Janeiro"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "governador do estado do Rio de Janeiro"
       },
       "name_en" : {
         "xml:lang" : "en",
@@ -64,6 +84,11 @@
         "type" : "literal",
         "value" : "Luiz Fernando de Souza"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Luiz Fernando Pezão"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53738324"
@@ -72,6 +97,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "cabinet of the governor of the state of Rio de Janeiro"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "cabinete do governador do estado do Rio de Janeiro"
       },
       "statement" : {
         "type" : "uri",

--- a/executive/Q53738324/current/query-used.rq
+++ b/executive/Q53738324/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739338 }
   BIND(wd:Q53738324 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738327/current/popolo-m17n.json
+++ b/executive/Q53738327/current/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Rui Costa",
         "lang:pt": "Rui Costa",
         "lang:en": "Rui Costa"
       },
@@ -23,6 +24,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "cabinete do governador do estado da Bahia",
         "lang:en": "cabinet of the governor of the state of Bahia"
       },
       "id": "Q53738327",
@@ -37,6 +39,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido dos Trabalhadores",
         "lang:pt": "Partido dos Trabalhadores",
         "lang:en": "Workers' Party"
       },
@@ -67,6 +70,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -93,6 +97,7 @@
         "Q53864926"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -111,10 +116,12 @@
       "area_id": "Q40430",
       "role_superclass_code": "Q53739339",
       "role_superclass": {
+        "lang:pt-br": "governador do estado da Bahia",
         "lang:en": "governor of the state of Bahia"
       },
       "role_code": "Q53739339",
       "role": {
+        "lang:pt-br": "governador do estado da Bahia",
         "lang:en": "governor of the state of Bahia"
       }
     }

--- a/executive/Q53738327/current/query-results.json
+++ b/executive/Q53738327/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido dos Trabalhadores"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido dos Trabalhadores"
       },
@@ -36,6 +41,11 @@
         "type" : "literal",
         "value" : "Bahia"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Bahia"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53739339"
@@ -49,10 +59,20 @@
         "type" : "literal",
         "value" : "governor of the state of Bahia"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "governador do estado da Bahia"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "governor of the state of Bahia"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "governador do estado da Bahia"
       },
       "name_en" : {
         "xml:lang" : "en",
@@ -64,6 +84,11 @@
         "type" : "literal",
         "value" : "Rui Costa"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Rui Costa"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53738327"
@@ -72,6 +97,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "cabinet of the governor of the state of Bahia"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "cabinete do governador do estado da Bahia"
       },
       "statement" : {
         "type" : "uri",

--- a/executive/Q53738327/current/query-used.rq
+++ b/executive/Q53738327/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739339 }
   BIND(wd:Q53738327 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738329/current/popolo-m17n.json
+++ b/executive/Q53738329/current/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "José Ivo Sartori",
         "lang:pt": "José Ivo Sartori",
         "lang:en": "José Ivo Sartori"
       },
@@ -27,6 +28,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "cabinete do governador do estado do Rio Grande do Sul",
         "lang:en": "cabinet of the governor of the state of Rio Grande do Sul"
       },
       "id": "Q53738329",
@@ -41,6 +43,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Movimento Democrático Brasileiro",
         "lang:pt": "Movimento Democrático Brasileiro",
         "lang:en": "Democratic Movement Party"
       },
@@ -71,6 +74,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -97,6 +101,7 @@
         "Q53864927"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -115,10 +120,12 @@
       "area_id": "Q40030",
       "role_superclass_code": "Q53739340",
       "role_superclass": {
+        "lang:pt-br": "governador do estado do Rio Grande do Sul",
         "lang:en": "governor of the state of Rio Grande do Sul"
       },
       "role_code": "Q53739340",
       "role": {
+        "lang:pt-br": "governador do estado do Rio Grande do Sul",
         "lang:en": "governor of the state of Rio Grande do Sul"
       }
     }

--- a/executive/Q53738329/current/query-results.json
+++ b/executive/Q53738329/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Movimento Democrático Brasileiro"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Movimento Democrático Brasileiro"
       },
@@ -36,6 +41,11 @@
         "type" : "literal",
         "value" : "Rio Grande do Sul"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Rio Grande do Sul"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53739340"
@@ -49,10 +59,20 @@
         "type" : "literal",
         "value" : "governor of the state of Rio Grande do Sul"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "governador do estado do Rio Grande do Sul"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "governor of the state of Rio Grande do Sul"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "governador do estado do Rio Grande do Sul"
       },
       "name_en" : {
         "xml:lang" : "en",
@@ -64,6 +84,11 @@
         "type" : "literal",
         "value" : "José Ivo Sartori"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "José Ivo Sartori"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53738329"
@@ -72,6 +97,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "cabinet of the governor of the state of Rio Grande do Sul"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "cabinete do governador do estado do Rio Grande do Sul"
       },
       "statement" : {
         "type" : "uri",
@@ -100,6 +130,11 @@
         "type" : "literal",
         "value" : "Movimento Democrático Brasileiro"
       },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Movimento Democrático Brasileiro"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q10309629"
@@ -118,6 +153,11 @@
         "type" : "literal",
         "value" : "Rio Grande do Sul"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Rio Grande do Sul"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53739340"
@@ -131,10 +171,20 @@
         "type" : "literal",
         "value" : "governor of the state of Rio Grande do Sul"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "governador do estado do Rio Grande do Sul"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "governor of the state of Rio Grande do Sul"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "governador do estado do Rio Grande do Sul"
       },
       "name_en" : {
         "xml:lang" : "en",
@@ -146,6 +196,11 @@
         "type" : "literal",
         "value" : "José Ivo Sartori"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "José Ivo Sartori"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53738329"
@@ -154,6 +209,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "cabinet of the governor of the state of Rio Grande do Sul"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "cabinete do governador do estado do Rio Grande do Sul"
       },
       "statement" : {
         "type" : "uri",

--- a/executive/Q53738329/current/query-used.rq
+++ b/executive/Q53738329/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739340 }
   BIND(wd:Q53738329 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738330/current/popolo-m17n.json
+++ b/executive/Q53738330/current/popolo-m17n.json
@@ -23,6 +23,7 @@
         "Q53864928"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -47,6 +48,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },

--- a/executive/Q53738330/current/query-results.json
+++ b/executive/Q53738330/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738330/current/query-used.rq
+++ b/executive/Q53738330/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739343 }
   BIND(wd:Q53738330 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738332/current/popolo-m17n.json
+++ b/executive/Q53738332/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864929"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738332/current/query-results.json
+++ b/executive/Q53738332/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738332/current/query-used.rq
+++ b/executive/Q53738332/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739344 }
   BIND(wd:Q53738332 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738333/current/popolo-m17n.json
+++ b/executive/Q53738333/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864930"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738333/current/query-results.json
+++ b/executive/Q53738333/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738333/current/query-used.rq
+++ b/executive/Q53738333/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739345 }
   BIND(wd:Q53738333 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738335/current/popolo-m17n.json
+++ b/executive/Q53738335/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864931"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738335/current/query-results.json
+++ b/executive/Q53738335/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738335/current/query-used.rq
+++ b/executive/Q53738335/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739346 }
   BIND(wd:Q53738335 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738342/current/popolo-m17n.json
+++ b/executive/Q53738342/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864932"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738342/current/query-results.json
+++ b/executive/Q53738342/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738342/current/query-used.rq
+++ b/executive/Q53738342/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739354 }
   BIND(wd:Q53738342 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738348/current/popolo-m17n.json
+++ b/executive/Q53738348/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864933"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738348/current/query-results.json
+++ b/executive/Q53738348/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738348/current/query-used.rq
+++ b/executive/Q53738348/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739358 }
   BIND(wd:Q53738348 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738350/current/popolo-m17n.json
+++ b/executive/Q53738350/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864934"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738350/current/query-results.json
+++ b/executive/Q53738350/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738350/current/query-used.rq
+++ b/executive/Q53738350/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739360 }
   BIND(wd:Q53738350 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738351/current/popolo-m17n.json
+++ b/executive/Q53738351/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864935"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738351/current/query-results.json
+++ b/executive/Q53738351/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738351/current/query-used.rq
+++ b/executive/Q53738351/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739362 }
   BIND(wd:Q53738351 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738352/current/popolo-m17n.json
+++ b/executive/Q53738352/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864936"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738352/current/query-results.json
+++ b/executive/Q53738352/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738352/current/query-used.rq
+++ b/executive/Q53738352/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739363 }
   BIND(wd:Q53738352 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738354/current/popolo-m17n.json
+++ b/executive/Q53738354/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864937"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738354/current/query-results.json
+++ b/executive/Q53738354/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738354/current/query-used.rq
+++ b/executive/Q53738354/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739364 }
   BIND(wd:Q53738354 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738355/current/popolo-m17n.json
+++ b/executive/Q53738355/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864938"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738355/current/query-results.json
+++ b/executive/Q53738355/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738355/current/query-used.rq
+++ b/executive/Q53738355/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739366 }
   BIND(wd:Q53738355 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738356/current/popolo-m17n.json
+++ b/executive/Q53738356/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864939"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738356/current/query-results.json
+++ b/executive/Q53738356/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738356/current/query-used.rq
+++ b/executive/Q53738356/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739367 }
   BIND(wd:Q53738356 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738357/current/popolo-m17n.json
+++ b/executive/Q53738357/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864940"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738357/current/query-results.json
+++ b/executive/Q53738357/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738357/current/query-used.rq
+++ b/executive/Q53738357/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739368 }
   BIND(wd:Q53738357 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738367/current/popolo-m17n.json
+++ b/executive/Q53738367/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864941"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738367/current/query-results.json
+++ b/executive/Q53738367/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738367/current/query-used.rq
+++ b/executive/Q53738367/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739375 }
   BIND(wd:Q53738367 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738372/current/popolo-m17n.json
+++ b/executive/Q53738372/current/popolo-m17n.json
@@ -46,6 +46,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },

--- a/executive/Q53738372/current/query-results.json
+++ b/executive/Q53738372/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738372/current/query-used.rq
+++ b/executive/Q53738372/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739380 }
   BIND(wd:Q53738372 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738373/current/popolo-m17n.json
+++ b/executive/Q53738373/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864943"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738373/current/query-results.json
+++ b/executive/Q53738373/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738373/current/query-used.rq
+++ b/executive/Q53738373/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739381 }
   BIND(wd:Q53738373 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738374/current/popolo-m17n.json
+++ b/executive/Q53738374/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864944"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738374/current/query-results.json
+++ b/executive/Q53738374/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738374/current/query-used.rq
+++ b/executive/Q53738374/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739383 }
   BIND(wd:Q53738374 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738377/current/popolo-m17n.json
+++ b/executive/Q53738377/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864945"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738377/current/query-results.json
+++ b/executive/Q53738377/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738377/current/query-used.rq
+++ b/executive/Q53738377/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739384 }
   BIND(wd:Q53738377 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738378/current/popolo-m17n.json
+++ b/executive/Q53738378/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864946"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738378/current/query-results.json
+++ b/executive/Q53738378/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738378/current/query-used.rq
+++ b/executive/Q53738378/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739385 }
   BIND(wd:Q53738378 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738379/current/popolo-m17n.json
+++ b/executive/Q53738379/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864947"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738379/current/query-results.json
+++ b/executive/Q53738379/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738379/current/query-used.rq
+++ b/executive/Q53738379/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q47520037 }
   BIND(wd:Q53738379 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738380/current/popolo-m17n.json
+++ b/executive/Q53738380/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864948"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738380/current/query-results.json
+++ b/executive/Q53738380/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738380/current/query-used.rq
+++ b/executive/Q53738380/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739389 }
   BIND(wd:Q53738380 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53738381/current/popolo-m17n.json
+++ b/executive/Q53738381/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864949"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53738381/current/query-results.json
+++ b/executive/Q53738381/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53738381/current/query-used.rq
+++ b/executive/Q53738381/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53739390 }
   BIND(wd:Q53738381 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53930899/current/popolo-m17n.json
+++ b/executive/Q53930899/current/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Marcelo Crivellla",
         "lang:pt": "Marcelo Crivella",
         "lang:en": "Marcelo Crivellla"
       },
@@ -23,6 +24,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "prefeitura municipal de Rio de Janeiro",
         "lang:en": "municipal prefecture of Rio de Janeiro"
       },
       "id": "Q53930899",
@@ -37,6 +39,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido Republicano Brasileiro",
         "lang:pt": "Partido Republicano Brasileiro",
         "lang:en": "Brazilian Republican Party"
       },
@@ -67,6 +70,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -93,6 +97,7 @@
         "Q53864925"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -118,6 +123,7 @@
         "Q53934881"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },
@@ -136,10 +142,12 @@
       "area_id": "Q8678",
       "role_superclass_code": "Q53926032",
       "role_superclass": {
+        "lang:pt-br": "Prefeito do Rio de Janeiro",
         "lang:en": "Mayor of Rio de Janeiro"
       },
       "role_code": "Q53926032",
       "role": {
+        "lang:pt-br": "Prefeito do Rio de Janeiro",
         "lang:en": "Mayor of Rio de Janeiro"
       }
     }

--- a/executive/Q53930899/current/query-results.json
+++ b/executive/Q53930899/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido Republicano Brasileiro"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido Republicano Brasileiro"
       },
@@ -36,6 +41,11 @@
         "type" : "literal",
         "value" : "Rio de Janeiro"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Rio de Janeiro"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53926032"
@@ -49,10 +59,20 @@
         "type" : "literal",
         "value" : "Mayor of Rio de Janeiro"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Prefeito do Rio de Janeiro"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Mayor of Rio de Janeiro"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Prefeito do Rio de Janeiro"
       },
       "name_en" : {
         "xml:lang" : "en",
@@ -64,6 +84,11 @@
         "type" : "literal",
         "value" : "Marcelo Crivella"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Marcelo Crivellla"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53930899"
@@ -72,6 +97,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "municipal prefecture of Rio de Janeiro"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de Rio de Janeiro"
       },
       "statement" : {
         "type" : "uri",

--- a/executive/Q53930899/current/query-used.rq
+++ b/executive/Q53930899/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53926032 }
   BIND(wd:Q53930899 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53930901/current/popolo-m17n.json
+++ b/executive/Q53930901/current/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Antônio Carlos Magalhães",
         "lang:pt": "Antônio Carlos Magalhães",
         "lang:en": "Antônio Carlos Magalhães"
       },
@@ -18,6 +19,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Antônio Carlos Peixoto de Magalhães Neto",
         "lang:pt": "Antônio Carlos Magalhães Neto",
         "lang:en": "Antônio Carlos Peixoto de Magalhães Neto"
       },
@@ -39,6 +41,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "prefeitura municipal de Salvador",
         "lang:en": "municipal prefecture of Salvador"
       },
       "id": "Q53930901",
@@ -69,6 +72,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -95,6 +99,7 @@
         "Q53934982"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },
@@ -120,6 +125,7 @@
         "Q53864926"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -137,11 +143,13 @@
       "area_id": "Q36947",
       "role_superclass_code": "Q27306390",
       "role_superclass": {
+        "lang:pt-br": "prefeito de Salvador",
         "lang:pt": "prefeito de Salvador",
         "lang:en": "mayor of Salvador"
       },
       "role_code": "Q27306390",
       "role": {
+        "lang:pt-br": "prefeito de Salvador",
         "lang:pt": "prefeito de Salvador",
         "lang:en": "mayor of Salvador"
       }
@@ -153,11 +161,13 @@
       "area_id": "Q36947",
       "role_superclass_code": "Q27306390",
       "role_superclass": {
+        "lang:pt-br": "prefeito de Salvador",
         "lang:pt": "prefeito de Salvador",
         "lang:en": "mayor of Salvador"
       },
       "role_code": "Q27306390",
       "role": {
+        "lang:pt-br": "prefeito de Salvador",
         "lang:pt": "prefeito de Salvador",
         "lang:en": "mayor of Salvador"
       }

--- a/executive/Q53930901/current/query-results.json
+++ b/executive/Q53930901/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "district_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Salvador"
+      },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Salvador"
       },
@@ -36,6 +41,11 @@
         "type" : "literal",
         "value" : "prefeito de Salvador"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeito de Salvador"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -43,6 +53,11 @@
       },
       "role_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "prefeito de Salvador"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "prefeito de Salvador"
       },
@@ -60,6 +75,11 @@
         "type" : "literal",
         "value" : "Antônio Carlos Magalhães"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Antônio Carlos Magalhães"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53930901"
@@ -68,6 +88,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "municipal prefecture of Salvador"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de Salvador"
       },
       "statement" : {
         "type" : "uri",
@@ -92,6 +117,11 @@
         "type" : "literal",
         "value" : "Salvador"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Salvador"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q27306390"
@@ -110,6 +140,11 @@
         "type" : "literal",
         "value" : "prefeito de Salvador"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeito de Salvador"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
@@ -117,6 +152,11 @@
       },
       "role_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "prefeito de Salvador"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "prefeito de Salvador"
       },
@@ -134,6 +174,11 @@
         "type" : "literal",
         "value" : "Antônio Carlos Magalhães Neto"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Antônio Carlos Peixoto de Magalhães Neto"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53930901"
@@ -142,6 +187,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "municipal prefecture of Salvador"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de Salvador"
       },
       "statement" : {
         "type" : "uri",

--- a/executive/Q53930901/current/query-used.rq
+++ b/executive/Q53930901/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q27306390 }
   BIND(wd:Q53930901 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53930902/current/popolo-m17n.json
+++ b/executive/Q53930902/current/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Roberto Cláudio Rodrigues Bezerra",
         "lang:pt": "Roberto Cláudio",
         "lang:en": "Roberto Cláudio Rodrigues Bezerra"
       },
@@ -27,6 +28,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "prefeitura municipal de Fortaleza",
         "lang:en": "municipal prefecture of Fortaleza"
       },
       "id": "Q53930902",
@@ -41,6 +43,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido Socialista Brasileiro",
         "lang:pt": "Partido Socialista Brasileiro",
         "lang:en": "Brazilian Socialist Party"
       },
@@ -71,6 +74,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -97,6 +101,7 @@
         "Q53864930"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -122,6 +127,7 @@
         "Q53935000"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },
@@ -140,10 +146,12 @@
       "area_id": "Q43463",
       "role_superclass_code": "Q53926033",
       "role_superclass": {
+        "lang:pt-br": "Prefeito de Fortaleza",
         "lang:en": "Mayor of Fortaleza"
       },
       "role_code": "Q53926033",
       "role": {
+        "lang:pt-br": "Prefeito de Fortaleza",
         "lang:en": "Mayor of Fortaleza"
       }
     }

--- a/executive/Q53930902/current/query-results.json
+++ b/executive/Q53930902/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido Socialista Brasileiro"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido Socialista Brasileiro"
       },
@@ -36,6 +41,11 @@
         "type" : "literal",
         "value" : "Fortaleza"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Fortaleza"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53926033"
@@ -49,10 +59,20 @@
         "type" : "literal",
         "value" : "Mayor of Fortaleza"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Prefeito de Fortaleza"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Mayor of Fortaleza"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Prefeito de Fortaleza"
       },
       "name_en" : {
         "xml:lang" : "en",
@@ -64,6 +84,11 @@
         "type" : "literal",
         "value" : "Roberto Cláudio"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Roberto Cláudio Rodrigues Bezerra"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53930902"
@@ -72,6 +97,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "municipal prefecture of Fortaleza"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de Fortaleza"
       },
       "statement" : {
         "type" : "uri",
@@ -100,6 +130,11 @@
         "type" : "literal",
         "value" : "Partido Socialista Brasileiro"
       },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Partido Socialista Brasileiro"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q7351650"
@@ -118,6 +153,11 @@
         "type" : "literal",
         "value" : "Fortaleza"
       },
+      "district_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Fortaleza"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53926033"
@@ -131,10 +171,20 @@
         "type" : "literal",
         "value" : "Mayor of Fortaleza"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Prefeito de Fortaleza"
+      },
       "role_en" : {
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Mayor of Fortaleza"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Prefeito de Fortaleza"
       },
       "name_en" : {
         "xml:lang" : "en",
@@ -146,6 +196,11 @@
         "type" : "literal",
         "value" : "Roberto Cláudio"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Roberto Cláudio Rodrigues Bezerra"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53930902"
@@ -154,6 +209,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "municipal prefecture of Fortaleza"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "prefeitura municipal de Fortaleza"
       },
       "statement" : {
         "type" : "uri",

--- a/executive/Q53930902/current/query-used.rq
+++ b/executive/Q53930902/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53926033 }
   BIND(wd:Q53930902 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53930905/current/popolo-m17n.json
+++ b/executive/Q53930905/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864935"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53935014"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },

--- a/executive/Q53930905/current/query-results.json
+++ b/executive/Q53930905/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53930905/current/query-used.rq
+++ b/executive/Q53930905/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53926036 }
   BIND(wd:Q53930905 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53930907/current/popolo-m17n.json
+++ b/executive/Q53930907/current/popolo-m17n.json
@@ -23,6 +23,7 @@
         "Q53864928"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -47,6 +48,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -73,6 +75,7 @@
         "Q53935038"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },

--- a/executive/Q53930907/current/query-results.json
+++ b/executive/Q53930907/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53930907/current/query-used.rq
+++ b/executive/Q53930907/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53926039 }
   BIND(wd:Q53930907 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53930910/current/popolo-m17n.json
+++ b/executive/Q53930910/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864929"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53935045"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },

--- a/executive/Q53930910/current/query-results.json
+++ b/executive/Q53930910/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53930910/current/query-used.rq
+++ b/executive/Q53930910/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53926041 }
   BIND(wd:Q53930910 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53930913/current/popolo-m17n.json
+++ b/executive/Q53930913/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864927"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53935050"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },

--- a/executive/Q53930913/current/query-results.json
+++ b/executive/Q53930913/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53930913/current/query-used.rq
+++ b/executive/Q53930913/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53926042 }
   BIND(wd:Q53930913 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53930914/current/popolo-m17n.json
+++ b/executive/Q53930914/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864934"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53935075"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },

--- a/executive/Q53930914/current/query-results.json
+++ b/executive/Q53930914/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53930914/current/query-used.rq
+++ b/executive/Q53930914/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53926044 }
   BIND(wd:Q53930914 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53930915/current/popolo-m17n.json
+++ b/executive/Q53930915/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864931"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53935627"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },

--- a/executive/Q53930915/current/query-results.json
+++ b/executive/Q53930915/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53930915/current/query-used.rq
+++ b/executive/Q53930915/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53926047 }
   BIND(wd:Q53930915 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53930928/current/popolo-m17n.json
+++ b/executive/Q53930928/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864923"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53935633"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },

--- a/executive/Q53930928/current/query-results.json
+++ b/executive/Q53930928/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53930928/current/query-used.rq
+++ b/executive/Q53930928/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53926062 }
   BIND(wd:Q53930928 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53930937/current/popolo-m17n.json
+++ b/executive/Q53930937/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53935638"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53864923"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53930937/current/query-results.json
+++ b/executive/Q53930937/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53930937/current/query-used.rq
+++ b/executive/Q53930937/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53926063 }
   BIND(wd:Q53930937 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/executive/Q53930939/current/popolo-m17n.json
+++ b/executive/Q53930939/current/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53935641"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53864933"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/executive/Q53930939/current/query-results.json
+++ b/executive/Q53930939/current/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt", "role_superclass_en", "org", "org_pt", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "start", "end", "facebook", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/executive/Q53930939/current/query-used.rq
+++ b/executive/Q53930939/current/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
        ?start ?end ?facebook
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
-       ?org ?org_pt ?org_en ?org_jurisdiction
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction
 WHERE {
   VALUES ?role_superclass { wd:Q53926065 }
   BIND(wd:Q53930939 AS ?org)
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -22,6 +26,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -31,6 +39,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -40,6 +52,10 @@ OPTIONAL {
         }
   ?role wdt:P279* ?role_superclass .
   OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -51,6 +67,10 @@ OPTIONAL {
   OPTIONAL {
     ?role p:P1001/ps:P1001 ?district .
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -68,6 +88,10 @@ OPTIONAL {
     ?item p:P102 ?party_statement .
     ?party_statement ps:P102 ?party .
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q10262893/Q53865289/popolo-m17n.json
+++ b/legislative/Q10262893/Q53865289/popolo-m17n.json
@@ -46,6 +46,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },

--- a/legislative/Q10262893/Q53865289/query-results.json
+++ b/legislative/Q10262893/Q53865289/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q10262893/Q53865289/query-used.rq
+++ b/legislative/Q10262893/Q53865289/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864942 as ?role) .
   BIND(wd:Q10262893 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q12243888/Q53865258/popolo-m17n.json
+++ b/legislative/Q12243888/Q53865258/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Gustavo Corrêa",
         "lang:pt": "Gustavo de Faria Dias Corrêa",
         "lang:en": "Gustavo Corrêa"
       },
@@ -23,6 +24,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "assembleia legislativa do estado de Minas Gerais",
         "lang:pt": "Assembleia Legislativa do Estado de Minas Gerais",
         "lang:en": "Legislative Assembly of Minas Gerais"
       },
@@ -41,6 +43,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Democratas",
         "lang:pt": "Democratas",
         "lang:en": "Democrats"
       },
@@ -71,6 +74,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -97,6 +101,7 @@
         "Q53864924"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -119,6 +124,7 @@
       },
       "role_code": "Q53864924",
       "role": {
+        "lang:pt-br": "deutado estadual de Minas Gerais",
         "lang:en": "state deputy of Minas Gerais"
       }
     }

--- a/legislative/Q12243888/Q53865258/query-results.json
+++ b/legislative/Q12243888/Q53865258/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Democratas"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Democratas"
       },
@@ -45,6 +50,11 @@
         "type" : "literal",
         "value" : "state deputy of Minas Gerais"
       },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "deutado estadual de Minas Gerais"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q10293157"
@@ -59,6 +69,11 @@
         "type" : "literal",
         "value" : "Gustavo de Faria Dias Corrêa"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Gustavo Corrêa"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q12243888"
@@ -72,6 +87,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Assembleia Legislativa do Estado de Minas Gerais"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "assembleia legislativa do estado de Minas Gerais"
       },
       "org_jurisdiction" : {
         "type" : "uri",

--- a/legislative/Q12243888/Q53865258/query-used.rq
+++ b/legislative/Q12243888/Q53865258/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864924 as ?role) .
   BIND(wd:Q12243888 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q12270300/Q53865281/popolo-m17n.json
+++ b/legislative/Q12270300/Q53865281/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864938"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q12270300/Q53865281/query-results.json
+++ b/legislative/Q12270300/Q53865281/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q12270300/Q53865281/query-used.rq
+++ b/legislative/Q12270300/Q53865281/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864938 as ?role) .
   BIND(wd:Q12270300 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q12469964/Q53865270/popolo-m17n.json
+++ b/legislative/Q12469964/Q53865270/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864931"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q12469964/Q53865270/query-results.json
+++ b/legislative/Q12469964/Q53865270/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q12469964/Q53865270/query-used.rq
+++ b/legislative/Q12469964/Q53865270/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864931 as ?role) .
   BIND(wd:Q12469964 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q13163502/Q53865268/popolo-m17n.json
+++ b/legislative/Q13163502/Q53865268/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864930"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q13163502/Q53865268/query-results.json
+++ b/legislative/Q13163502/Q53865268/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q13163502/Q53865268/query-used.rq
+++ b/legislative/Q13163502/Q53865268/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864930 as ?role) .
   BIND(wd:Q13163502 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q16142313/Q53865283/popolo-m17n.json
+++ b/legislative/Q16142313/Q53865283/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864939"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q16142313/Q53865283/query-results.json
+++ b/legislative/Q16142313/Q53865283/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q16142313/Q53865283/query-used.rq
+++ b/legislative/Q16142313/Q53865283/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864939 as ?role) .
   BIND(wd:Q16142313 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q16142333/Q53865296/popolo-m17n.json
+++ b/legislative/Q16142333/Q53865296/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864947"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q16142333/Q53865296/query-results.json
+++ b/legislative/Q16142333/Q53865296/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q16142333/Q53865296/query-used.rq
+++ b/legislative/Q16142333/Q53865296/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864947 as ?role) .
   BIND(wd:Q16142333 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q16494759/Q53865287/popolo-m17n.json
+++ b/legislative/Q16494759/Q53865287/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864941"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q16494759/Q53865287/query-results.json
+++ b/legislative/Q16494759/Q53865287/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q16494759/Q53865287/query-used.rq
+++ b/legislative/Q16494759/Q53865287/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864941 as ?role) .
   BIND(wd:Q16494759 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q16494760/Q53865292/popolo-m17n.json
+++ b/legislative/Q16494760/Q53865292/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864945"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q16494760/Q53865292/query-results.json
+++ b/legislative/Q16494760/Q53865292/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q16494760/Q53865292/query-used.rq
+++ b/legislative/Q16494760/Q53865292/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864945 as ?role) .
   BIND(wd:Q16494760 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q16498710/Q53865285/popolo-m17n.json
+++ b/legislative/Q16498710/Q53865285/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864940"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q16498710/Q53865285/query-results.json
+++ b/legislative/Q16498710/Q53865285/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q16498710/Q53865285/query-used.rq
+++ b/legislative/Q16498710/Q53865285/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864940 as ?role) .
   BIND(wd:Q16498710 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q1834804/Q18479094/popolo-m17n.json
+++ b/legislative/Q1834804/Q18479094/popolo-m17n.json
@@ -98,6 +98,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Paulo Pimenta",
         "lang:pt": "Paulo Pimenta",
         "lang:en": "Paulo Pimenta"
       },
@@ -377,6 +378,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "André Figueiredo",
         "lang:pt": "André Figueiredo",
         "lang:en": "André Figueiredo"
       },
@@ -412,6 +414,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Nilson Leitão",
         "lang:pt": "Nilson Leitão",
         "lang:en": "Nilson Leitão"
       },
@@ -850,6 +853,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Victório Galli",
         "lang:pt": "Victório Galli",
         "lang:en": "Victório Galli"
       },
@@ -869,6 +873,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "José Alberto Fogaça de Medeiros",
         "lang:pt": "José Fogaça",
         "lang:en": "José Fogaça"
       },
@@ -980,6 +985,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Baleia Rossi",
         "lang:pt": "Baleia Rossi",
         "lang:en": "Baleia Rossi"
       },
@@ -1001,6 +1007,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "Câmara dos Deputados",
         "lang:pt": "Câmara dos Deputados do Brasil",
         "lang:en": "Chamber of Deputies"
       },
@@ -1019,6 +1026,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Movimento Democrático Brasileiro",
         "lang:pt": "Movimento Democrático Brasileiro",
         "lang:en": "Democratic Movement Party"
       },
@@ -1033,6 +1041,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido da Social Democracia Brasileira",
         "lang:pt": "Partido da Social Democracia Brasileira",
         "lang:en": "Brazilian Social Democracy Party"
       },
@@ -1047,6 +1056,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido Democrático Trabalhista",
         "lang:pt": "Partido Democrático Trabalhista",
         "lang:en": "Democratic Labour Party"
       },
@@ -1061,6 +1071,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido Social Cristão",
         "lang:pt": "Partido Social Cristão",
         "lang:en": "Social Christian Party"
       },
@@ -1075,6 +1086,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido dos Trabalhadores",
         "lang:pt": "Partido dos Trabalhadores",
         "lang:en": "Workers' Party"
       },
@@ -1105,6 +1117,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -1743,11 +1756,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1758,11 +1773,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1773,11 +1790,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1788,11 +1807,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1803,11 +1824,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1818,11 +1841,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1835,11 +1860,13 @@
       "area_id": "Q53657915",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1850,11 +1877,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1865,11 +1894,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1880,11 +1911,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1895,11 +1928,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1910,11 +1945,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1925,11 +1962,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1940,11 +1979,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1955,11 +1996,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1970,11 +2013,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -1985,11 +2030,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2000,11 +2047,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2015,11 +2064,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2030,11 +2081,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2045,11 +2098,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2060,11 +2115,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2075,11 +2132,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2092,11 +2151,13 @@
       "area_id": "Q53657931",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2107,11 +2168,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2124,11 +2187,13 @@
       "area_id": "Q53657991",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2139,11 +2204,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2154,11 +2221,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2169,11 +2238,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2187,11 +2258,13 @@
       "end_date": "2016-10-19",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2205,11 +2278,13 @@
       "end_date": "2016-11-24",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2221,11 +2296,13 @@
       "area_id": "Q53657970",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2236,11 +2313,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2251,11 +2330,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2266,11 +2347,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2281,11 +2364,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2296,11 +2381,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2311,11 +2398,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2326,11 +2415,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2341,11 +2432,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2356,11 +2449,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2371,11 +2466,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2386,11 +2483,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2401,11 +2500,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2416,11 +2517,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2431,11 +2534,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2446,11 +2551,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2461,11 +2568,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2476,11 +2585,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2493,11 +2604,13 @@
       "start_date": "2015-09-03",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2508,11 +2621,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2523,11 +2638,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2540,11 +2657,13 @@
       "area_id": "Q53657991",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2555,11 +2674,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2571,11 +2692,13 @@
       "start_date": "2017-01-02",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2586,11 +2709,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2601,11 +2726,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2616,11 +2743,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2631,11 +2760,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2646,11 +2777,13 @@
       "organization_id": "Q1834804",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }
@@ -2663,11 +2796,13 @@
       "area_id": "Q53657905",
       "role_superclass_code": "Q1055894",
       "role_superclass": {
+        "lang:pt-br": "Deputado",
         "lang:pt": "deputado",
         "lang:en": "deputy"
       },
       "role_code": "Q20058725",
       "role": {
+        "lang:pt-br": "Deputado federal",
         "lang:pt": "deputado do Brasil",
         "lang:en": "member of the Chamber of Deputies of Brazil"
       }

--- a/legislative/Q1834804/Q18479094/query-results.json
+++ b/legislative/Q1834804/Q18479094/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ {
@@ -22,6 +22,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -35,6 +40,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -58,6 +68,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -92,6 +107,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -105,6 +125,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -128,6 +153,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -162,6 +192,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -175,6 +210,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -198,6 +238,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -232,6 +277,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -245,6 +295,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -268,6 +323,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -302,6 +362,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -315,6 +380,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -338,6 +408,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -372,6 +447,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -385,6 +465,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -408,6 +493,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -442,6 +532,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -455,6 +550,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -478,6 +578,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -507,6 +612,11 @@
         "type" : "literal",
         "value" : "Partido dos Trabalhadores"
       },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Partido dos Trabalhadores"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53657915"
@@ -515,6 +625,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Rio Grande do Sul"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Paulo Pimenta"
       },
       "facebook" : {
         "type" : "literal",
@@ -539,6 +654,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -552,6 +672,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -575,6 +700,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -609,6 +739,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -622,6 +757,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -645,6 +785,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -679,6 +824,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -692,6 +842,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -715,6 +870,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -749,6 +909,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -762,6 +927,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -785,6 +955,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -819,6 +994,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -832,6 +1012,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -855,6 +1040,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -889,6 +1079,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -902,6 +1097,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -925,6 +1125,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -959,6 +1164,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -972,6 +1182,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -995,6 +1210,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1029,6 +1249,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -1042,6 +1267,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -1065,6 +1295,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1099,6 +1334,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -1112,6 +1352,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -1135,6 +1380,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1164,6 +1414,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -1177,6 +1432,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -1200,6 +1460,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1234,6 +1499,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -1247,6 +1517,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -1270,6 +1545,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1308,6 +1588,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -1321,6 +1606,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -1344,6 +1634,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1382,6 +1677,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -1395,6 +1695,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -1418,6 +1723,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1452,6 +1762,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -1465,6 +1780,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -1488,6 +1808,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1517,6 +1842,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -1530,6 +1860,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -1553,6 +1888,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1587,6 +1927,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -1600,6 +1945,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -1623,6 +1973,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1657,6 +2012,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -1670,6 +2030,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -1693,6 +2058,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1722,6 +2092,11 @@
         "type" : "literal",
         "value" : "Partido Democrático Trabalhista"
       },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Partido Democrático Trabalhista"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53657931"
@@ -1730,6 +2105,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Ceará"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "André Figueiredo"
       },
       "facebook" : {
         "type" : "literal",
@@ -1754,6 +2134,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -1767,6 +2152,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -1790,6 +2180,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1824,6 +2219,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -1837,6 +2237,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -1860,6 +2265,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1889,6 +2299,11 @@
         "type" : "literal",
         "value" : "Partido da Social Democracia Brasileira"
       },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Partido da Social Democracia Brasileira"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53657991"
@@ -1897,6 +2312,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Mato Grosso do Sul"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Nilson Leitão"
       },
       "facebook" : {
         "type" : "literal",
@@ -1921,6 +2341,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -1934,6 +2359,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -1957,6 +2387,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -1991,6 +2426,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -2004,6 +2444,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -2027,6 +2472,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2061,6 +2511,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -2074,6 +2529,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -2097,6 +2557,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2135,6 +2600,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -2148,6 +2618,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -2171,6 +2646,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2224,6 +2704,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -2237,6 +2722,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -2260,6 +2750,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2313,6 +2808,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -2326,6 +2826,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -2349,6 +2854,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2392,6 +2902,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -2405,6 +2920,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -2428,6 +2948,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2462,6 +2987,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -2475,6 +3005,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -2498,6 +3033,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2532,6 +3072,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -2545,6 +3090,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -2568,6 +3118,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2602,6 +3157,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -2615,6 +3175,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -2638,6 +3203,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2672,6 +3242,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -2685,6 +3260,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -2708,6 +3288,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2742,6 +3327,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -2755,6 +3345,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -2778,6 +3373,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2812,6 +3412,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -2825,6 +3430,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -2848,6 +3458,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2882,6 +3497,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -2895,6 +3515,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -2918,6 +3543,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -2952,6 +3582,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -2965,6 +3600,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -2988,6 +3628,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3022,6 +3667,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -3035,6 +3685,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -3058,6 +3713,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3092,6 +3752,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -3105,6 +3770,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -3128,6 +3798,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3162,6 +3837,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -3175,6 +3855,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -3198,6 +3883,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3232,6 +3922,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -3245,6 +3940,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -3268,6 +3968,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3302,6 +4007,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -3315,6 +4025,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -3338,6 +4053,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3372,6 +4092,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -3385,6 +4110,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -3408,6 +4138,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3442,6 +4177,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -3455,6 +4195,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -3478,6 +4223,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3512,6 +4262,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -3525,6 +4280,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -3548,6 +4308,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3582,6 +4347,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -3595,6 +4365,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -3618,6 +4393,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3666,6 +4446,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -3679,6 +4464,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -3702,6 +4492,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3736,6 +4531,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -3749,6 +4549,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -3772,6 +4577,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3806,6 +4616,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -3819,6 +4634,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -3842,6 +4662,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -3871,6 +4696,11 @@
         "type" : "literal",
         "value" : "Partido Social Cristão"
       },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Partido Social Cristão"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53657991"
@@ -3879,6 +4709,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Mato Grosso do Sul"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Victório Galli"
       },
       "facebook" : {
         "type" : "literal",
@@ -3903,6 +4738,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -3916,6 +4756,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -3940,6 +4785,11 @@
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
       },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
+      },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q155"
@@ -3953,6 +4803,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "José Fogaça"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "José Alberto Fogaça de Medeiros"
       }
     }, {
       "statement" : {
@@ -3973,6 +4828,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -3986,6 +4846,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -4009,6 +4874,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -4048,6 +4918,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -4061,6 +4936,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -4084,6 +4964,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -4113,6 +4998,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -4126,6 +5016,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -4149,6 +5044,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -4183,6 +5083,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -4196,6 +5101,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -4219,6 +5129,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -4253,6 +5168,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -4266,6 +5186,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -4289,6 +5214,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -4323,6 +5253,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -4336,6 +5271,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -4359,6 +5299,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -4393,6 +5338,11 @@
         "type" : "literal",
         "value" : "deputado"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q20058725"
@@ -4406,6 +5356,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "deputado do Brasil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Deputado federal"
       },
       "item" : {
         "type" : "uri",
@@ -4429,6 +5384,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara dos Deputados do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara dos Deputados"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -4458,6 +5418,11 @@
         "type" : "literal",
         "value" : "Movimento Democrático Brasileiro"
       },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Movimento Democrático Brasileiro"
+      },
       "district" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53657905"
@@ -4466,6 +5431,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "São Paulo"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Baleia Rossi"
       },
       "facebook" : {
         "type" : "literal",

--- a/legislative/Q1834804/Q18479094/query-used.rq
+++ b/legislative/Q1834804/Q18479094/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q20058725 as ?role) .
   BIND(wd:Q1834804 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q1834804/Q53865845/popolo-m17n.json
+++ b/legislative/Q1834804/Q53865845/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },

--- a/legislative/Q1834804/Q53865845/query-results.json
+++ b/legislative/Q1834804/Q53865845/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q1834804/Q53865845/query-used.rq
+++ b/legislative/Q1834804/Q53865845/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q20058725 as ?role) .
   BIND(wd:Q1834804 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q2119413/Q53865845/popolo-m17n.json
+++ b/legislative/Q2119413/Q53865845/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Lindbergh Farias",
         "lang:pt": "Lindberg Farias",
         "lang:en": "Lindbergh Farias"
       },
@@ -21,6 +22,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Ronaldo Caiado",
         "lang:pt": "Ronaldo Caiado",
         "lang:en": "Ronaldo Caiado"
       },
@@ -40,6 +42,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Simone Tebet",
         "lang:pt": "Simone Tebet",
         "lang:en": "Simone Tebet"
       },
@@ -59,6 +62,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Paulo Bauer",
         "lang:pt": "Paulo Bauer",
         "lang:en": "Paulo Bauer"
       },
@@ -78,6 +82,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Vanessa Grazziotin",
         "lang:pt": "Vanessa Grazziotin",
         "lang:en": "Vanessa Grazziotin"
       },
@@ -99,6 +104,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "Senado Federal",
         "lang:pt": "Senado Federal do Brasil",
         "lang:en": "Federal Senate of Brazil"
       },
@@ -117,6 +123,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Democratas",
         "lang:pt": "Democratas",
         "lang:en": "Democrats"
       },
@@ -131,6 +138,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Movimento Democrático Brasileiro",
         "lang:pt": "Movimento Democrático Brasileiro",
         "lang:en": "Democratic Movement Party"
       },
@@ -145,6 +153,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido da Social Democracia Brasileira",
         "lang:pt": "Partido da Social Democracia Brasileira",
         "lang:en": "Brazilian Social Democracy Party"
       },
@@ -159,6 +168,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido Comunista do Brasil",
         "lang:pt": "Partido Comunista do Brasil",
         "lang:en": "Communist Party of Brazil"
       },
@@ -173,6 +183,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido dos Trabalhadores",
         "lang:pt": "Partido dos Trabalhadores",
         "lang:en": "Workers' Party"
       },
@@ -203,6 +214,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -843,11 +855,13 @@
       "area_id": "Q53657912",
       "role_superclass_code": "Q15686806",
       "role_superclass": {
+        "lang:pt-br": "Senador",
         "lang:pt": "senador",
         "lang:en": "senator"
       },
       "role_code": "Q18964326",
       "role": {
+        "lang:pt-br": "Senador",
         "lang:en": "Member of the Senate of Brazil"
       }
     },
@@ -859,11 +873,13 @@
       "area_id": "Q53657950",
       "role_superclass_code": "Q15686806",
       "role_superclass": {
+        "lang:pt-br": "Senador",
         "lang:pt": "senador",
         "lang:en": "senator"
       },
       "role_code": "Q18964326",
       "role": {
+        "lang:pt-br": "Senador",
         "lang:en": "Member of the Senate of Brazil"
       }
     },
@@ -875,11 +891,13 @@
       "area_id": "Q53657992",
       "role_superclass_code": "Q15686806",
       "role_superclass": {
+        "lang:pt-br": "Senador",
         "lang:pt": "senador",
         "lang:en": "senator"
       },
       "role_code": "Q18964326",
       "role": {
+        "lang:pt-br": "Senador",
         "lang:en": "Member of the Senate of Brazil"
       }
     },
@@ -891,11 +909,13 @@
       "area_id": "Q53657946",
       "role_superclass_code": "Q15686806",
       "role_superclass": {
+        "lang:pt-br": "Senador",
         "lang:pt": "senador",
         "lang:en": "senator"
       },
       "role_code": "Q18964326",
       "role": {
+        "lang:pt-br": "Senador",
         "lang:en": "Member of the Senate of Brazil"
       }
     },
@@ -907,11 +927,13 @@
       "area_id": "Q53657952",
       "role_superclass_code": "Q15686806",
       "role_superclass": {
+        "lang:pt-br": "Senador",
         "lang:pt": "senador",
         "lang:en": "senator"
       },
       "role_code": "Q18964326",
       "role": {
+        "lang:pt-br": "Senador",
         "lang:en": "Member of the Senate of Brazil"
       }
     }

--- a/legislative/Q2119413/Q53865845/query-results.json
+++ b/legislative/Q2119413/Q53865845/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido dos Trabalhadores"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido dos Trabalhadores"
       },
@@ -45,6 +50,11 @@
         "type" : "literal",
         "value" : "senador"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senador"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q18964326"
@@ -53,6 +63,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Member of the Senate of Brazil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senador"
       },
       "item" : {
         "type" : "uri",
@@ -68,6 +83,11 @@
         "type" : "literal",
         "value" : "Lindberg Farias"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Lindbergh Farias"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q2119413"
@@ -81,6 +101,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Senado Federal do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senado Federal"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -107,6 +132,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Democratas"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Democratas"
       },
@@ -137,6 +167,11 @@
         "type" : "literal",
         "value" : "senador"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senador"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q18964326"
@@ -145,6 +180,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Member of the Senate of Brazil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senador"
       },
       "item" : {
         "type" : "uri",
@@ -157,6 +197,11 @@
       },
       "name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Ronaldo Caiado"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Ronaldo Caiado"
       },
@@ -173,6 +218,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Senado Federal do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senado Federal"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -199,6 +249,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Movimento Democrático Brasileiro"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Movimento Democrático Brasileiro"
       },
@@ -229,6 +284,11 @@
         "type" : "literal",
         "value" : "senador"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senador"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q18964326"
@@ -237,6 +297,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Member of the Senate of Brazil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senador"
       },
       "item" : {
         "type" : "uri",
@@ -249,6 +314,11 @@
       },
       "name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Simone Tebet"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Simone Tebet"
       },
@@ -265,6 +335,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Senado Federal do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senado Federal"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -291,6 +366,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido da Social Democracia Brasileira"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido da Social Democracia Brasileira"
       },
@@ -321,6 +401,11 @@
         "type" : "literal",
         "value" : "senador"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senador"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q18964326"
@@ -329,6 +414,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Member of the Senate of Brazil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senador"
       },
       "item" : {
         "type" : "uri",
@@ -341,6 +431,11 @@
       },
       "name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Paulo Bauer"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Paulo Bauer"
       },
@@ -357,6 +452,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Senado Federal do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senado Federal"
       },
       "org_jurisdiction" : {
         "type" : "uri",
@@ -383,6 +483,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido Comunista do Brasil"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido Comunista do Brasil"
       },
@@ -413,6 +518,11 @@
         "type" : "literal",
         "value" : "senador"
       },
+      "role_superclass_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senador"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q18964326"
@@ -421,6 +531,11 @@
         "xml:lang" : "en",
         "type" : "literal",
         "value" : "Member of the Senate of Brazil"
+      },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senador"
       },
       "item" : {
         "type" : "uri",
@@ -433,6 +548,11 @@
       },
       "name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Vanessa Grazziotin"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Vanessa Grazziotin"
       },
@@ -449,6 +569,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Senado Federal do Brasil"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Senado Federal"
       },
       "org_jurisdiction" : {
         "type" : "uri",

--- a/legislative/Q2119413/Q53865845/query-used.rq
+++ b/legislative/Q2119413/Q53865845/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q18964326 as ?role) .
   BIND(wd:Q2119413 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q4808730/Q53865257/popolo-m17n.json
+++ b/legislative/Q4808730/Q53865257/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Roberto Massafera",
         "lang:pt": "Roberto Massafera",
         "lang:en": "Roberto Massafera"
       },
@@ -23,6 +24,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "Assembleia Legislativa de São Paulo",
         "lang:pt": "Assembleia Legislativa de São Paulo",
         "lang:en": "Legislative Assembly of São Paulo"
       },
@@ -41,6 +43,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido da Social Democracia Brasileira",
         "lang:pt": "Partido da Social Democracia Brasileira",
         "lang:en": "Brazilian Social Democracy Party"
       },
@@ -71,6 +74,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -97,6 +101,7 @@
         "Q53864923"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -119,6 +124,7 @@
       },
       "role_code": "Q53864923",
       "role": {
+        "lang:pt-br": "deutado estadual de São Paulo",
         "lang:en": "state deputy of São Paulo"
       }
     }

--- a/legislative/Q4808730/Q53865257/query-results.json
+++ b/legislative/Q4808730/Q53865257/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido da Social Democracia Brasileira"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido da Social Democracia Brasileira"
       },
@@ -45,6 +50,11 @@
         "type" : "literal",
         "value" : "state deputy of São Paulo"
       },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "deutado estadual de São Paulo"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q28677607"
@@ -59,6 +69,11 @@
         "type" : "literal",
         "value" : "Roberto Massafera"
       },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Roberto Massafera"
+      },
       "org" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q4808730"
@@ -70,6 +85,11 @@
       },
       "org_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Assembleia Legislativa de São Paulo"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Assembleia Legislativa de São Paulo"
       },

--- a/legislative/Q4808730/Q53865257/query-used.rq
+++ b/legislative/Q4808730/Q53865257/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864923 as ?role) .
   BIND(wd:Q4808730 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q53934974/Q53935631/popolo-m17n.json
+++ b/legislative/Q53934974/Q53935631/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864931"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53935627"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },

--- a/legislative/Q53934974/Q53935631/query-results.json
+++ b/legislative/Q53934974/Q53935631/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q53934974/Q53935631/query-used.rq
+++ b/legislative/Q53934974/Q53935631/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53935627 as ?role) .
   BIND(wd:Q53934974 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q53934976/Q53935636/popolo-m17n.json
+++ b/legislative/Q53934976/Q53935636/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864923"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53935633"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },

--- a/legislative/Q53934976/Q53935636/query-results.json
+++ b/legislative/Q53934976/Q53935636/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q53934976/Q53935636/query-used.rq
+++ b/legislative/Q53934976/Q53935636/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53935633 as ?role) .
   BIND(wd:Q53934976 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q53934977/Q53949902/popolo-m17n.json
+++ b/legislative/Q53934977/Q53949902/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53935638"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53864923"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q53934977/Q53949902/query-results.json
+++ b/legislative/Q53934977/Q53949902/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q53934977/Q53949902/query-used.rq
+++ b/legislative/Q53934977/Q53949902/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53935638 as ?role) .
   BIND(wd:Q53934977 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q53934979/Q53935643/popolo-m17n.json
+++ b/legislative/Q53934979/Q53935643/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53935641"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53864933"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q53934979/Q53935643/query-results.json
+++ b/legislative/Q53934979/Q53935643/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q53934979/Q53935643/query-used.rq
+++ b/legislative/Q53934979/Q53935643/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53935641 as ?role) .
   BIND(wd:Q53934979 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q53934981/Q53934997/popolo-m17n.json
+++ b/legislative/Q53934981/Q53934997/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Aladilce Souza",
         "lang:en": "Aladilce Souza"
       },
       "id": "Q53939225",
@@ -22,6 +23,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "Câmara Municipal de Salvador",
         "lang:pt": "Câmara Municipal de Salvador",
         "lang:en": "Municipal Chamber of Salvador"
       },
@@ -40,6 +42,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido Comunista do Brasil",
         "lang:pt": "Partido Comunista do Brasil",
         "lang:en": "Communist Party of Brazil"
       },
@@ -70,6 +73,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -96,6 +100,7 @@
         "Q53934982"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },
@@ -121,6 +126,7 @@
         "Q53864926"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -143,6 +149,7 @@
       },
       "role_code": "Q53934982",
       "role": {
+        "lang:pt-br": "Vereador de Salvador",
         "lang:en": "Councillor of Salvador"
       }
     }

--- a/legislative/Q53934981/Q53934997/query-results.json
+++ b/legislative/Q53934981/Q53934997/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido Comunista do Brasil"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido Comunista do Brasil"
       },
@@ -45,12 +50,22 @@
         "type" : "literal",
         "value" : "Councillor of Salvador"
       },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Vereador de Salvador"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53939225"
       },
       "name_en" : {
         "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Aladilce Souza"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Aladilce Souza"
       },
@@ -65,6 +80,11 @@
       },
       "org_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Câmara Municipal de Salvador"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Câmara Municipal de Salvador"
       },

--- a/legislative/Q53934981/Q53934997/query-used.rq
+++ b/legislative/Q53934981/Q53934997/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53934982 as ?role) .
   BIND(wd:Q53934981 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q53934998/Q53935002/popolo-m17n.json
+++ b/legislative/Q53934998/Q53935002/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "João Salmito Filho",
         "lang:en": "João Salmito Filho"
       },
       "id": "Q53939228",
@@ -22,6 +23,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "Câmara Municipal de Fortaleza",
         "lang:pt": "Câmara Municipal de Fortaleza",
         "lang:en": "Municipal Chamber of Fortaleza"
       },
@@ -40,6 +42,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido Democrático Trabalhista",
         "lang:pt": "Partido Democrático Trabalhista",
         "lang:en": "Democratic Labour Party"
       },
@@ -70,6 +73,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -96,6 +100,7 @@
         "Q53864930"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -121,6 +126,7 @@
         "Q53935000"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },
@@ -143,6 +149,7 @@
       },
       "role_code": "Q53935000",
       "role": {
+        "lang:pt-br": "Vereador de Fortaleza",
         "lang:en": "Councillor of Fortaleza"
       }
     }

--- a/legislative/Q53934998/Q53935002/query-results.json
+++ b/legislative/Q53934998/Q53935002/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido Democrático Trabalhista"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido Democrático Trabalhista"
       },
@@ -45,12 +50,22 @@
         "type" : "literal",
         "value" : "Councillor of Fortaleza"
       },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Vereador de Fortaleza"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53939228"
       },
       "name_en" : {
         "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "João Salmito Filho"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "João Salmito Filho"
       },
@@ -65,6 +80,11 @@
       },
       "org_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Câmara Municipal de Fortaleza"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Câmara Municipal de Fortaleza"
       },

--- a/legislative/Q53934998/Q53935002/query-used.rq
+++ b/legislative/Q53934998/Q53935002/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53935000 as ?role) .
   BIND(wd:Q53934998 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q53935004/Q53935009/popolo-m17n.json
+++ b/legislative/Q53935004/Q53935009/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Henrique Braga",
         "lang:en": "Henrique Braga"
       },
       "id": "Q53939229",
@@ -22,6 +23,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "Câmara Municipal do Belo Horizonte",
         "lang:pt": "Câmara Municipal de Belo Horizonte",
         "lang:en": "Municipal Chamber of Belo Horizonte"
       },
@@ -40,6 +42,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido da Social Democracia Brasileira",
         "lang:pt": "Partido da Social Democracia Brasileira",
         "lang:en": "Brazilian Social Democracy Party"
       },
@@ -70,6 +73,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -96,6 +100,7 @@
         "Q53864924"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -121,6 +126,7 @@
         "Q53935007"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },
@@ -143,6 +149,7 @@
       },
       "role_code": "Q53935007",
       "role": {
+        "lang:pt-br": "Vereador de Belo Horizonte",
         "lang:en": "Councillor of Belo Horizonte"
       }
     }

--- a/legislative/Q53935004/Q53935009/query-results.json
+++ b/legislative/Q53935004/Q53935009/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido da Social Democracia Brasileira"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido da Social Democracia Brasileira"
       },
@@ -45,12 +50,22 @@
         "type" : "literal",
         "value" : "Councillor of Belo Horizonte"
       },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Vereador de Belo Horizonte"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53939229"
       },
       "name_en" : {
         "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Henrique Braga"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Henrique Braga"
       },
@@ -67,6 +82,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Câmara Municipal de Belo Horizonte"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Câmara Municipal do Belo Horizonte"
       },
       "org_jurisdiction" : {
         "type" : "uri",

--- a/legislative/Q53935004/Q53935009/query-used.rq
+++ b/legislative/Q53935004/Q53935009/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53935007 as ?role) .
   BIND(wd:Q53935004 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q53935013/Q53935032/popolo-m17n.json
+++ b/legislative/Q53935013/Q53935032/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864935"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53935014"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },

--- a/legislative/Q53935013/Q53935032/query-results.json
+++ b/legislative/Q53935013/Q53935032/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q53935013/Q53935032/query-used.rq
+++ b/legislative/Q53935013/Q53935032/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53935014 as ?role) .
   BIND(wd:Q53935013 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q53935035/Q53935039/popolo-m17n.json
+++ b/legislative/Q53935035/Q53935039/popolo-m17n.json
@@ -23,6 +23,7 @@
         "Q53864928"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -47,6 +48,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -73,6 +75,7 @@
         "Q53935038"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },

--- a/legislative/Q53935035/Q53935039/query-results.json
+++ b/legislative/Q53935035/Q53935039/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q53935035/Q53935039/query-used.rq
+++ b/legislative/Q53935035/Q53935039/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53935038 as ?role) .
   BIND(wd:Q53935035 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q53935043/Q53935047/popolo-m17n.json
+++ b/legislative/Q53935043/Q53935047/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864929"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53935045"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },

--- a/legislative/Q53935043/Q53935047/query-results.json
+++ b/legislative/Q53935043/Q53935047/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q53935043/Q53935047/query-used.rq
+++ b/legislative/Q53935043/Q53935047/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53935045 as ?role) .
   BIND(wd:Q53935043 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q53935048/Q53935071/popolo-m17n.json
+++ b/legislative/Q53935048/Q53935071/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864927"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53935050"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },

--- a/legislative/Q53935048/Q53935071/query-results.json
+++ b/legislative/Q53935048/Q53935071/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q53935048/Q53935071/query-used.rq
+++ b/legislative/Q53935048/Q53935071/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53935050 as ?role) .
   BIND(wd:Q53935048 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q53935073/Q53935076/popolo-m17n.json
+++ b/legislative/Q53935073/Q53935076/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864934"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -73,6 +75,7 @@
         "Q53935075"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },

--- a/legislative/Q53935073/Q53935076/query-results.json
+++ b/legislative/Q53935073/Q53935076/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q53935073/Q53935076/query-used.rq
+++ b/legislative/Q53935073/Q53935076/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53935075 as ?role) .
   BIND(wd:Q53935073 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q6518202/Q53865277/popolo-m17n.json
+++ b/legislative/Q6518202/Q53865277/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864935"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q6518202/Q53865277/query-results.json
+++ b/legislative/Q6518202/Q53865277/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q6518202/Q53865277/query-used.rq
+++ b/legislative/Q6518202/Q53865277/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864935 as ?role) .
   BIND(wd:Q6518202 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q6583209/Q53865261/popolo-m17n.json
+++ b/legislative/Q6583209/Q53865261/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Cidinha Campos",
         "lang:pt": "Cidinha Campos",
         "lang:en": "Cidinha Campos"
       },
@@ -23,6 +24,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "assembleia legislativa do estado do Rio de Janeiro",
         "lang:pt": "Assembleia Legislativa do Estado do Rio de Janeiro",
         "lang:en": "Legislative Assembly of Rio de Janeiro"
       },
@@ -41,6 +43,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido Democrático Trabalhista",
         "lang:pt": "Partido Democrático Trabalhista",
         "lang:en": "Democratic Labour Party"
       },
@@ -71,6 +74,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -97,6 +101,7 @@
         "Q53864925"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -119,6 +124,7 @@
       },
       "role_code": "Q53864925",
       "role": {
+        "lang:pt-br": "deutado estadual de Rio de Janeiro",
         "lang:en": "state deputy of Rio de Janeiro"
       }
     }

--- a/legislative/Q6583209/Q53865261/query-results.json
+++ b/legislative/Q6583209/Q53865261/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido Democrático Trabalhista"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido Democrático Trabalhista"
       },
@@ -45,6 +50,11 @@
         "type" : "literal",
         "value" : "state deputy of Rio de Janeiro"
       },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "deutado estadual de Rio de Janeiro"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q9759994"
@@ -56,6 +66,11 @@
       },
       "name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Cidinha Campos"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Cidinha Campos"
       },
@@ -72,6 +87,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Assembleia Legislativa do Estado do Rio de Janeiro"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "assembleia legislativa do estado do Rio de Janeiro"
       },
       "org_jurisdiction" : {
         "type" : "uri",

--- a/legislative/Q6583209/Q53865261/query-used.rq
+++ b/legislative/Q6583209/Q53865261/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864925 as ?role) .
   BIND(wd:Q6583209 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q6936214/Q53934884/popolo-m17n.json
+++ b/legislative/Q6936214/Q53934884/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Tânia Bastos",
         "lang:en": "Tânia Bastos"
       },
       "id": "Q53939223",
@@ -22,6 +23,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "Câmara Municipal do Rio de Janeiro",
         "lang:pt": "Câmara Municipal do Rio de Janeiro",
         "lang:en": "Municipal Chamber of Rio de Janeiro"
       },
@@ -40,6 +42,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido Republicano Brasileiro",
         "lang:pt": "Partido Republicano Brasileiro",
         "lang:en": "Brazilian Republican Party"
       },
@@ -70,6 +73,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -96,6 +100,7 @@
         "Q53864925"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -121,6 +126,7 @@
         "Q53934881"
       ],
       "type": {
+        "lang:pt-br": "município do Brasil",
         "lang:pt": "município do Brasil",
         "lang:en": "municipality of Brazil"
       },
@@ -143,6 +149,7 @@
       },
       "role_code": "Q53934881",
       "role": {
+        "lang:pt-br": "Vereador de Rio de Janeiro",
         "lang:en": "Councillor of Rio de Janeiro"
       }
     }

--- a/legislative/Q6936214/Q53934884/query-results.json
+++ b/legislative/Q6936214/Q53934884/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido Republicano Brasileiro"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido Republicano Brasileiro"
       },
@@ -45,12 +50,22 @@
         "type" : "literal",
         "value" : "Councillor of Rio de Janeiro"
       },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Vereador de Rio de Janeiro"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53939223"
       },
       "name_en" : {
         "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Tânia Bastos"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Tânia Bastos"
       },
@@ -65,6 +80,11 @@
       },
       "org_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Câmara Municipal do Rio de Janeiro"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Câmara Municipal do Rio de Janeiro"
       },

--- a/legislative/Q6936214/Q53934884/query-used.rq
+++ b/legislative/Q6936214/Q53934884/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53934881 as ?role) .
   BIND(wd:Q6936214 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q6936217/Q53934880/popolo-m17n.json
+++ b/legislative/Q6936217/Q53934880/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Milton Leite",
         "lang:en": "Milton Leite"
       },
       "id": "Q53864959",
@@ -22,6 +23,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "Câmara Municipal de São Paulo",
         "lang:pt": "Câmara Municipal de São Paulo",
         "lang:en": "Municipal Chamber of Sao Paulo"
       },
@@ -40,6 +42,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Democratas",
         "lang:pt": "Democratas",
         "lang:en": "Democrats"
       },
@@ -70,6 +73,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -96,6 +100,7 @@
         "Q53934877"
       ],
       "type": {
+        "lang:pt-br": "capital",
         "lang:pt": "capital",
         "lang:en": "capital"
       },
@@ -121,6 +126,7 @@
         "Q53864923"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -143,6 +149,7 @@
       },
       "role_code": "Q53934877",
       "role": {
+        "lang:pt-br": "Vereador de São Paulo",
         "lang:en": "Councillor of São Paulo"
       }
     }

--- a/legislative/Q6936217/Q53934880/query-results.json
+++ b/legislative/Q6936217/Q53934880/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Democratas"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Democratas"
       },
@@ -45,12 +50,22 @@
         "type" : "literal",
         "value" : "Councillor of São Paulo"
       },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Vereador de São Paulo"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q53864959"
       },
       "name_en" : {
         "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Milton Leite"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Milton Leite"
       },
@@ -65,6 +80,11 @@
       },
       "org_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Câmara Municipal de São Paulo"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Câmara Municipal de São Paulo"
       },

--- a/legislative/Q6936217/Q53934880/query-used.rq
+++ b/legislative/Q6936217/Q53934880/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53934877 as ?role) .
   BIND(wd:Q6936217 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q9633173/Q53865278/popolo-m17n.json
+++ b/legislative/Q9633173/Q53865278/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864936"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q9633173/Q53865278/query-results.json
+++ b/legislative/Q9633173/Q53865278/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q9633173/Q53865278/query-used.rq
+++ b/legislative/Q9633173/Q53865278/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864936 as ?role) .
   BIND(wd:Q9633173 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q9633175/Q53865262/popolo-m17n.json
+++ b/legislative/Q9633175/Q53865262/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Luiza Maia",
         "lang:pt": "Luiza Maia",
         "lang:en": "Luiza Maia"
       },
@@ -23,6 +24,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "assembleia legislativa do estado da Bahia",
         "lang:pt": "Assembleia Legislativa da Bahia",
         "lang:en": "Legislative Assembly of Bahia"
       },
@@ -41,6 +43,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido dos Trabalhadores",
         "lang:pt": "Partido dos Trabalhadores",
         "lang:en": "Workers' Party"
       },
@@ -71,6 +74,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -97,6 +101,7 @@
         "Q53864926"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -119,6 +124,7 @@
       },
       "role_code": "Q53864926",
       "role": {
+        "lang:pt-br": "deutado estadual de Bahia",
         "lang:en": "state deputy of Bahia"
       }
     }

--- a/legislative/Q9633175/Q53865262/query-results.json
+++ b/legislative/Q9633175/Q53865262/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido dos Trabalhadores"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido dos Trabalhadores"
       },
@@ -45,6 +50,11 @@
         "type" : "literal",
         "value" : "state deputy of Bahia"
       },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "deutado estadual de Bahia"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q10320900"
@@ -56,6 +66,11 @@
       },
       "name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Luiza Maia"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Luiza Maia"
       },
@@ -72,6 +87,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Assembleia Legislativa da Bahia"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "assembleia legislativa do estado da Bahia"
       },
       "org_jurisdiction" : {
         "type" : "uri",

--- a/legislative/Q9633175/Q53865262/query-used.rq
+++ b/legislative/Q9633175/Q53865262/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864926 as ?role) .
   BIND(wd:Q9633175 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q9633183/Q53865274/popolo-m17n.json
+++ b/legislative/Q9633183/Q53865274/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864934"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q9633183/Q53865274/query-results.json
+++ b/legislative/Q9633183/Q53865274/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q9633183/Q53865274/query-used.rq
+++ b/legislative/Q9633183/Q53865274/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864934 as ?role) .
   BIND(wd:Q9633183 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q9633190/Q53865290/popolo-m17n.json
+++ b/legislative/Q9633190/Q53865290/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864943"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q9633190/Q53865290/query-results.json
+++ b/legislative/Q9633190/Q53865290/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q9633190/Q53865290/query-used.rq
+++ b/legislative/Q9633190/Q53865290/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864943 as ?role) .
   BIND(wd:Q9633190 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q9633197/Q53865267/popolo-m17n.json
+++ b/legislative/Q9633197/Q53865267/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864929"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q9633197/Q53865267/query-results.json
+++ b/legislative/Q9633197/Q53865267/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q9633197/Q53865267/query-used.rq
+++ b/legislative/Q9633197/Q53865267/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864929 as ?role) .
   BIND(wd:Q9633197 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q9633200/Q53865299/popolo-m17n.json
+++ b/legislative/Q9633200/Q53865299/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864949"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q9633200/Q53865299/query-results.json
+++ b/legislative/Q9633200/Q53865299/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q9633200/Q53865299/query-used.rq
+++ b/legislative/Q9633200/Q53865299/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864949 as ?role) .
   BIND(wd:Q9633200 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q9633202/Q53865291/popolo-m17n.json
+++ b/legislative/Q9633202/Q53865291/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864944"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q9633202/Q53865291/query-results.json
+++ b/legislative/Q9633202/Q53865291/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q9633202/Q53865291/query-used.rq
+++ b/legislative/Q9633202/Q53865291/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864944 as ?role) .
   BIND(wd:Q9633202 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q9633207/Q53865272/popolo-m17n.json
+++ b/legislative/Q9633207/Q53865272/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864932"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q9633207/Q53865272/query-results.json
+++ b/legislative/Q9633207/Q53865272/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q9633207/Q53865272/query-used.rq
+++ b/legislative/Q9633207/Q53865272/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864932 as ?role) .
   BIND(wd:Q9633207 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q9633212/Q53865298/popolo-m17n.json
+++ b/legislative/Q9633212/Q53865298/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864948"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q9633212/Q53865298/query-results.json
+++ b/legislative/Q9633212/Q53865298/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q9633212/Q53865298/query-used.rq
+++ b/legislative/Q9633212/Q53865298/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864948 as ?role) .
   BIND(wd:Q9633212 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q9633218/Q53865279/popolo-m17n.json
+++ b/legislative/Q9633218/Q53865279/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864937"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q9633218/Q53865279/query-results.json
+++ b/legislative/Q9633218/Q53865279/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q9633218/Q53865279/query-used.rq
+++ b/legislative/Q9633218/Q53865279/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864937 as ?role) .
   BIND(wd:Q9633218 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q9633221/Q53865273/popolo-m17n.json
+++ b/legislative/Q9633221/Q53865273/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864933"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q9633221/Q53865273/query-results.json
+++ b/legislative/Q9633221/Q53865273/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q9633221/Q53865273/query-used.rq
+++ b/legislative/Q9633221/Q53865273/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864933 as ?role) .
   BIND(wd:Q9633221 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q9633230/Q53865264/popolo-m17n.json
+++ b/legislative/Q9633230/Q53865264/popolo-m17n.json
@@ -23,6 +23,7 @@
         "Q53864928"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -47,6 +48,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },

--- a/legislative/Q9633230/Q53865264/query-results.json
+++ b/legislative/Q9633230/Q53865264/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q9633230/Q53865264/query-used.rq
+++ b/legislative/Q9633230/Q53865264/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864928 as ?role) .
   BIND(wd:Q9633230 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q9633239/Q53865263/popolo-m17n.json
+++ b/legislative/Q9633239/Q53865263/popolo-m17n.json
@@ -2,6 +2,7 @@
   "persons": [
     {
       "name": {
+        "lang:pt-br": "Marlon Santos",
         "lang:pt": "Marlon Santos",
         "lang:en": "Marlon Santos"
       },
@@ -23,6 +24,7 @@
   "organizations": [
     {
       "name": {
+        "lang:pt-br": "assembleia legislativa do estado do Rio Grande do Sul",
         "lang:pt": "Assembleia Legislativa do Rio Grande do Sul",
         "lang:en": "Legislative Assembly of Rio Grande do Sul"
       },
@@ -41,6 +43,7 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido Democrático Trabalhista",
         "lang:pt": "Partido Democrático Trabalhista",
         "lang:en": "Democratic Labour Party"
       },
@@ -71,6 +74,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -97,6 +101,7 @@
         "Q53864927"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },
@@ -119,6 +124,7 @@
       },
       "role_code": "Q53864927",
       "role": {
+        "lang:pt-br": "deutado estadual de Rio Grande do Sul",
         "lang:en": "state deputy of Rio Grande do Sul"
       }
     }

--- a/legislative/Q9633239/Q53865263/query-results.json
+++ b/legislative/Q9633239/Q53865263/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ {
@@ -15,6 +15,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido Democrático Trabalhista"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido Democrático Trabalhista"
       },
@@ -45,6 +50,11 @@
         "type" : "literal",
         "value" : "state deputy of Rio Grande do Sul"
       },
+      "role_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "deutado estadual de Rio Grande do Sul"
+      },
       "item" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q10326642"
@@ -56,6 +66,11 @@
       },
       "name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Marlon Santos"
+      },
+      "name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Marlon Santos"
       },
@@ -72,6 +87,11 @@
         "xml:lang" : "pt",
         "type" : "literal",
         "value" : "Assembleia Legislativa do Rio Grande do Sul"
+      },
+      "org_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "assembleia legislativa do estado do Rio Grande do Sul"
       },
       "org_jurisdiction" : {
         "type" : "uri",

--- a/legislative/Q9633239/Q53865263/query-used.rq
+++ b/legislative/Q9633239/Q53865263/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864927 as ?role) .
   BIND(wd:Q9633239 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }

--- a/legislative/Q9633245/Q53865294/popolo-m17n.json
+++ b/legislative/Q9633245/Q53865294/popolo-m17n.json
@@ -22,6 +22,7 @@
         "Q5176750"
       ],
       "type": {
+        "lang:pt-br": "país",
         "lang:pt": "país",
         "lang:en": "country"
       },
@@ -48,6 +49,7 @@
         "Q53864946"
       ],
       "type": {
+        "lang:pt-br": "unidades federativas",
         "lang:pt": "unidade federativa do Brasil",
         "lang:en": "Federative unit of Brazil"
       },

--- a/legislative/Q9633245/Q53865294/query-results.json
+++ b/legislative/Q9633245/Q53865294/query-results.json
@@ -1,6 +1,6 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_pt", "name_en", "party", "party_name_pt", "party_name_en", "district", "district_name_pt", "district_name_en", "role", "role_pt", "role_en", "role_superclass", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
+    "vars" : [ "statement", "item", "name_pt_br", "name_pt", "name_en", "party", "party_name_pt_br", "party_name_pt", "party_name_en", "district", "district_name_pt_br", "district_name_pt", "district_name_en", "role", "role_pt_br", "role_pt", "role_en", "role_superclass", "role_superclass_pt_br", "role_superclass_pt", "role_superclass_en", "start", "end", "facebook", "org", "org_pt_br", "org_pt", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ ]

--- a/legislative/Q9633245/Q53865294/query-used.rq
+++ b/legislative/Q9633245/Q53865294/query-used.rq
@@ -1,15 +1,19 @@
 SELECT ?statement
-       ?item ?name_pt ?name_en
-       ?party ?party_name_pt ?party_name_en
-       ?district ?district_name_pt ?district_name_en
-       ?role ?role_pt ?role_en
-       ?role_superclass ?role_superclass_pt ?role_superclass_en
+       ?item ?name_pt_br ?name_pt ?name_en
+       ?party ?party_name_pt_br ?party_name_pt ?party_name_en
+       ?district ?district_name_pt_br ?district_name_pt ?district_name_en
+       ?role ?role_pt_br ?role_pt ?role_en
+       ?role_superclass ?role_superclass_pt_br ?role_superclass_pt ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
+       ?org ?org_pt_br ?org_pt ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q53864946 as ?role) .
   BIND(wd:Q9633245 as ?org) .
   OPTIONAL {
+          ?org rdfs:label ?org_pt_br
+          FILTER(LANG(?org_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?org rdfs:label ?org_pt
           FILTER(LANG(?org_pt) = "pt")
         }
@@ -25,6 +29,10 @@ OPTIONAL {
   }
   ?item p:P39 ?statement .
   OPTIONAL {
+          ?item rdfs:label ?name_pt_br
+          FILTER(LANG(?name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?item rdfs:label ?name_pt
           FILTER(LANG(?name_pt) = "pt")
         }
@@ -34,6 +42,10 @@ OPTIONAL {
         }
   ?statement ps:P39 ?role .
   OPTIONAL {
+          ?role rdfs:label ?role_pt_br
+          FILTER(LANG(?role_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role rdfs:label ?role_pt
           FILTER(LANG(?role_pt) = "pt")
         }
@@ -45,6 +57,10 @@ OPTIONAL {
     ?role wdt:P279 ?role_superclass .
     ?role_superclass wdt:P279+ wd:Q4175034
     OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_pt_br
+          FILTER(LANG(?role_superclass_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?role_superclass rdfs:label ?role_superclass_pt
           FILTER(LANG(?role_superclass_pt) = "pt")
         }
@@ -59,6 +75,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
+          ?district rdfs:label ?district_name_pt_br
+          FILTER(LANG(?district_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?district rdfs:label ?district_name_pt
           FILTER(LANG(?district_name_pt) = "pt")
         }
@@ -70,6 +90,10 @@ OPTIONAL {
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
+          ?party rdfs:label ?party_name_pt_br
+          FILTER(LANG(?party_name_pt_br) = "pt-br")
+        }
+OPTIONAL {
           ?party rdfs:label ?party_name_pt
           FILTER(LANG(?party_name_pt) = "pt")
         }


### PR DESCRIPTION
Previously only the generic Portuguese labels were being fetched, but lots of items only have Portuguese labels under the pt-br language (Brazilian Portuguese). This PR includes those as well.