### PR TITLE
Refresh to clear up confused parties

### DIFF
--- a/executive/Q10351100/current/popolo-m17n.json
+++ b/executive/Q10351100/current/popolo-m17n.json
@@ -292,15 +292,16 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido Social Democrático",
         "lang:pt": "Partido Social Democrático",
         "lang:en": "Social Democratic Party"
       },
-      "id": "Q2626216",
+      "id": "Q2054750",
       "classification": "party",
       "identifiers": [
         {
           "scheme": "wikidata",
-          "identifier": "Q2626216"
+          "identifier": "Q2054750"
         }
       ]
     },
@@ -574,7 +575,7 @@
     {
       "id": "http://www.wikidata.org/entity/statement/Q2546210-89ac76a0-4dc2-1bf3-295e-48c7064e37d5",
       "person_id": "Q2546210",
-      "on_behalf_of_id": "Q2626216",
+      "on_behalf_of_id": "Q2054750",
       "organization_id": "Q10351100",
       "area_id": "Q174",
       "role_superclass_code": "Q30185",

--- a/executive/Q10351100/current/query-results.json
+++ b/executive/Q10351100/current/query-results.json
@@ -820,7 +820,12 @@
       },
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2626216"
+        "value" : "http://www.wikidata.org/entity/Q2054750"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
+        "type" : "literal",
+        "value" : "Partido Social Democrático"
       },
       "party_name_pt" : {
         "xml:lang" : "pt",

--- a/executive/Q5015503/current/popolo-m17n.json
+++ b/executive/Q5015503/current/popolo-m17n.json
@@ -110,11 +110,11 @@
       "on_behalf_of_id": "Q1322751",
       "organization_id": "Q5015503",
       "area_id": "Q155",
-      "role_superclass_code": "Q30461",
+      "role_superclass_code": "Q2285706",
       "role_superclass": {
-        "lang:pt-br": "presidente",
-        "lang:pt": "presidente",
-        "lang:en": "president"
+        "lang:pt-br": "Chefe de governo",
+        "lang:pt": "chefe de governo",
+        "lang:en": "head of government"
       },
       "role_code": "Q5176750",
       "role": {
@@ -129,26 +129,6 @@
       "on_behalf_of_id": "Q1322751",
       "organization_id": "Q5015503",
       "area_id": "Q155",
-      "role_superclass_code": "Q2285706",
-      "role_superclass": {
-        "lang:pt-br": "Chefe de governo",
-        "lang:pt": "chefe de governo",
-        "lang:en": "head of government"
-      },
-      "role_code": "Q5176750",
-      "role": {
-        "lang:pt-br": "Presidente do Brasil",
-        "lang:pt": "Presidente do Brasil",
-        "lang:en": "President of Brazil"
-      }
-    },
-    {
-      "id": "http://www.wikidata.org/entity/statement/Q463533-341dc2f2-4c16-dfb5-362f-ac0cae065c02",
-      "person_id": "Q463533",
-      "on_behalf_of_id": "Q1322751",
-      "organization_id": "Q5015503",
-      "area_id": "Q155",
-      "start_date": "2016-08-31",
       "role_superclass_code": "Q30461",
       "role_superclass": {
         "lang:pt-br": "presidente",
@@ -174,6 +154,26 @@
         "lang:pt-br": "Chefe de governo",
         "lang:pt": "chefe de governo",
         "lang:en": "head of government"
+      },
+      "role_code": "Q5176750",
+      "role": {
+        "lang:pt-br": "Presidente do Brasil",
+        "lang:pt": "Presidente do Brasil",
+        "lang:en": "President of Brazil"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q463533-341dc2f2-4c16-dfb5-362f-ac0cae065c02",
+      "person_id": "Q463533",
+      "on_behalf_of_id": "Q1322751",
+      "organization_id": "Q5015503",
+      "area_id": "Q155",
+      "start_date": "2016-08-31",
+      "role_superclass_code": "Q30461",
+      "role_superclass": {
+        "lang:pt-br": "presidente",
+        "lang:pt": "presidente",
+        "lang:en": "president"
       },
       "role_code": "Q5176750",
       "role": {

--- a/executive/Q5015503/current/query-results.json
+++ b/executive/Q5015503/current/query-results.json
@@ -86,22 +86,22 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q30461"
+        "value" : "http://www.wikidata.org/entity/Q2285706"
       },
       "role_superclass_pt_br" : {
         "xml:lang" : "pt-br",
         "type" : "literal",
-        "value" : "presidente"
+        "value" : "Chefe de governo"
       },
       "role_superclass_pt" : {
         "xml:lang" : "pt",
         "type" : "literal",
-        "value" : "presidente"
+        "value" : "chefe de governo"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "president"
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
@@ -209,22 +209,22 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2285706"
+        "value" : "http://www.wikidata.org/entity/Q30461"
       },
       "role_superclass_pt_br" : {
         "xml:lang" : "pt-br",
         "type" : "literal",
-        "value" : "Chefe de governo"
+        "value" : "presidente"
       },
       "role_superclass_pt" : {
         "xml:lang" : "pt",
         "type" : "literal",
-        "value" : "chefe de governo"
+        "value" : "presidente"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "head of government"
+        "value" : "president"
       },
       "org" : {
         "type" : "uri",
@@ -332,22 +332,22 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q30461"
+        "value" : "http://www.wikidata.org/entity/Q2285706"
       },
       "role_superclass_pt_br" : {
         "xml:lang" : "pt-br",
         "type" : "literal",
-        "value" : "presidente"
+        "value" : "Chefe de governo"
       },
       "role_superclass_pt" : {
         "xml:lang" : "pt",
         "type" : "literal",
-        "value" : "presidente"
+        "value" : "chefe de governo"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "president"
+        "value" : "head of government"
       },
       "org" : {
         "type" : "uri",
@@ -464,22 +464,22 @@
       },
       "role_superclass" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2285706"
+        "value" : "http://www.wikidata.org/entity/Q30461"
       },
       "role_superclass_pt_br" : {
         "xml:lang" : "pt-br",
         "type" : "literal",
-        "value" : "Chefe de governo"
+        "value" : "presidente"
       },
       "role_superclass_pt" : {
         "xml:lang" : "pt",
         "type" : "literal",
-        "value" : "chefe de governo"
+        "value" : "presidente"
       },
       "role_superclass_en" : {
         "xml:lang" : "en",
         "type" : "literal",
-        "value" : "head of government"
+        "value" : "president"
       },
       "org" : {
         "type" : "uri",

--- a/legislative/Q6936217/Q53934880/popolo-m17n.json
+++ b/legislative/Q6936217/Q53934880/popolo-m17n.json
@@ -1137,6 +1137,21 @@
     },
     {
       "name": {
+        "lang:pt-br": "Partido Social Democrático",
+        "lang:pt": "Partido Social Democrático",
+        "lang:en": "Social Democratic Party"
+      },
+      "id": "Q2054750",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q2054750"
+        }
+      ]
+    },
+    {
+      "name": {
         "lang:pt-br": "Partido Socialista Brasileiro",
         "lang:pt": "Partido Socialista Brasileiro",
         "lang:en": "Brazilian Socialist Party"
@@ -1192,20 +1207,6 @@
         {
           "scheme": "wikidata",
           "identifier": "Q2626213"
-        }
-      ]
-    },
-    {
-      "name": {
-        "lang:pt": "Partido Social Democrático",
-        "lang:en": "Social Democratic Party"
-      },
-      "id": "Q2626216",
-      "classification": "party",
-      "identifiers": [
-        {
-          "scheme": "wikidata",
-          "identifier": "Q2626216"
         }
       ]
     },
@@ -1511,7 +1512,7 @@
     {
       "id": "http://www.wikidata.org/entity/statement/Q53726977-41FC03EF-8B31-497A-A60C-0BA36EB67678",
       "person_id": "Q53726977",
-      "on_behalf_of_id": "Q2626216",
+      "on_behalf_of_id": "Q2054750",
       "organization_id": "Q6936217",
       "role_superclass_code": "Q708492",
       "role_superclass": {
@@ -1799,7 +1800,7 @@
     {
       "id": "http://www.wikidata.org/entity/statement/Q56195589-8C6963AD-558E-48A6-92C3-198E1BF97AB2",
       "person_id": "Q56195589",
-      "on_behalf_of_id": "Q2626216",
+      "on_behalf_of_id": "Q2054750",
       "organization_id": "Q6936217",
       "role_superclass_code": "Q708492",
       "role_superclass": {
@@ -2135,7 +2136,7 @@
     {
       "id": "http://www.wikidata.org/entity/statement/Q56195610-AA4F4E74-A045-41F5-A33B-CE821821BEE7",
       "person_id": "Q56195610",
-      "on_behalf_of_id": "Q2626216",
+      "on_behalf_of_id": "Q2054750",
       "organization_id": "Q6936217",
       "role_superclass_code": "Q708492",
       "role_superclass": {
@@ -2151,7 +2152,7 @@
     {
       "id": "http://www.wikidata.org/entity/statement/Q56195612-9EB47831-13AE-47A1-99DD-851D86E52651",
       "person_id": "Q56195612",
-      "on_behalf_of_id": "Q2626216",
+      "on_behalf_of_id": "Q2054750",
       "organization_id": "Q6936217",
       "role_superclass_code": "Q708492",
       "role_superclass": {

--- a/legislative/Q6936217/Q53934880/query-results.json
+++ b/legislative/Q6936217/Q53934880/query-results.json
@@ -816,7 +816,7 @@
     }, {
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2626216"
+        "value" : "http://www.wikidata.org/entity/Q2054750"
       },
       "party_name_en" : {
         "xml:lang" : "en",
@@ -825,6 +825,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido Social Democrático"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido Social Democrático"
       },
@@ -2568,7 +2573,7 @@
     }, {
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2626216"
+        "value" : "http://www.wikidata.org/entity/Q2054750"
       },
       "party_name_en" : {
         "xml:lang" : "en",
@@ -2577,6 +2582,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido Social Democrático"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido Social Democrático"
       },
@@ -4580,7 +4590,7 @@
     }, {
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2626216"
+        "value" : "http://www.wikidata.org/entity/Q2054750"
       },
       "party_name_en" : {
         "xml:lang" : "en",
@@ -4589,6 +4599,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido Social Democrático"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido Social Democrático"
       },
@@ -4673,7 +4688,7 @@
     }, {
       "party" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/Q2626216"
+        "value" : "http://www.wikidata.org/entity/Q2054750"
       },
       "party_name_en" : {
         "xml:lang" : "en",
@@ -4682,6 +4697,11 @@
       },
       "party_name_pt" : {
         "xml:lang" : "pt",
+        "type" : "literal",
+        "value" : "Partido Social Democrático"
+      },
+      "party_name_pt_br" : {
+        "xml:lang" : "pt-br",
         "type" : "literal",
         "value" : "Partido Social Democrático"
       },


### PR DESCRIPTION
As spotted by @crowbot, the upstream data confused https://www.wikidata.org/wiki/Q2626216 (old) and https://www.wikidata.org/wiki/Q2054750 (current). Updated in Wikidata; this PR pulls in the data fix.